### PR TITLE
Repo structure v2

### DIFF
--- a/Anthropic/claude-code-hooks/README.md
+++ b/Anthropic/claude-code-hooks/README.md
@@ -4,6 +4,19 @@
 
 A comprehensive defense-in-depth security framework that protects Claude Code interactions from advanced AI-specific threats including prompt injection, data exfiltration, malicious code execution, and indirect attacks through external content.
 
+## Coverage
+
+> For detection categories and use cases, see the [Prisma AIRS documentation](https://pan.dev/prisma-airs/api/airuntimesecurity/usecases/).
+
+| Scanning Phase | Supported | Description |
+|----------------|:---------:|-------------|
+| Prompt | ✅ | Scans user prompts via `UserPromptSubmit` hook before Claude processes |
+| Response | ✅ | Scans LLM responses via `PostToolUse` hook with JSON blocking |
+| Streaming | ❌ | Not implemented - processes complete responses only |
+| Pre-tool call | ✅ | Scans MCP tool parameters and URLs via `PreToolUse` hook |
+| Post-tool call | ✅ | Scans tool responses from MCP and WebFetch via `PostToolUse` hook |
+| MCP | ✅ | Advanced MCP scanning with regex-based tool matching |
+
 ## 🛡️ Executive Summary
 
 This repository implements a multi-layer security architecture that intercepts and analyzes all interactions with Claude Code using [Palo Alto Networks Prisma AIRS](https://www.paloaltonetworks.com/prisma/prisma-ai-runtime-security). The system provides real-time protection against both traditional cybersecurity threats and emerging AI-specific attack vectors.

--- a/Anthropic/claude-code-mcp/README.md
+++ b/Anthropic/claude-code-mcp/README.md
@@ -2,6 +2,19 @@
 
 Connect Claude Code to Prisma AIRS via the Model Context Protocol (MCP) for on-demand security scanning through native MCP tools.
 
+## Coverage
+
+> For detection categories and use cases, see the [Prisma AIRS documentation](https://pan.dev/prisma-airs/api/airuntimesecurity/usecases/).
+
+| Scanning Phase | Supported | Description |
+|----------------|:---------:|-------------|
+| Prompt | ✅ | Claude can invoke `pan_inline_scan` to scan user prompts on-demand |
+| Response | ✅ | Claude can invoke `pan_inline_scan` to scan LLM outputs on-demand |
+| Streaming | ❌ | MCP tools are blocking synchronous calls |
+| Pre-tool call | ❌ | Not automatic - Claude must explicitly invoke scanning |
+| Post-tool call | ❌ | Not automatic - Claude must explicitly invoke scanning |
+| MCP | ❌ | Provides MCP tools but does not intercept MCP interactions |
+
 ## Overview
 
 The Prisma AIRS MCP Server provides Claude Code with security scanning tools via the MCP protocol. Once configured, Claude can invoke AIRS scanning tools directly during conversations.

--- a/Anthropic/claude-code-skill/README.md
+++ b/Anthropic/claude-code-skill/README.md
@@ -2,6 +2,19 @@
 
 A Claude Code skill that integrates Palo Alto Networks Prisma AI Runtime Security (AIRS) for scanning prompts, code, and AI responses for security threats.
 
+## Coverage
+
+> For detection categories and use cases, see the [Prisma AIRS documentation](https://pan.dev/prisma-airs/api/airuntimesecurity/usecases/).
+
+| Scanning Phase | Supported | Description |
+|----------------|:---------:|-------------|
+| Prompt | ✅ | User-invoked via `/airs-scan` command with `--type prompt` |
+| Response | ✅ | User-invoked scanning of AI-generated content |
+| Streaming | ❌ | Synchronous blocking scan only |
+| Pre-tool call | ❌ | Not designed for pre-tool validation |
+| Post-tool call | ❌ | Not designed for post-tool validation |
+| MCP | ❌ | Not designed for MCP interactions |
+
 ## Features
 
 - **Prompt Injection Detection**: Identifies attempts to manipulate AI behavior

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,11 @@ Every integration README must include a Coverage section after the title/descrip
 | MCP | ❌ | Scans Model Context Protocol interactions |
 ```
 
+**Support icons:**
+- ✅ Full support
+- ⚠️ Partial/conditional support (describe conditions in Description column)
+- ❌ No support
+
 **Column definitions:**
 - **Prompt**: Scans user input before sending to LLM
 - **Response**: Scans LLM output before returning to user

--- a/Google/apigee/README.md
+++ b/Google/apigee/README.md
@@ -4,6 +4,19 @@ A production-ready Apigee X proxy that integrates **Prisma AIRS security scannin
 - **Prompt Scanning**: Block malicious prompts before they reach the LLM
 - **Response Scanning**: Block sensitive data in LLM responses (PII, credentials, etc.)
 
+## Coverage
+
+> For detection categories and use cases, see the [Prisma AIRS documentation](https://pan.dev/prisma-airs/api/airuntimesecurity/usecases/).
+
+| Scanning Phase | Supported | Description |
+|----------------|:---------:|-------------|
+| Prompt | ✅ | PreFlow scanning via ServiceCallout before Vertex AI call |
+| Response | ✅ | PostFlow scanning with masking support for Vertex AI responses |
+| Streaming | ❌ | Synchronous ServiceCallout with 5-second timeout |
+| Pre-tool call | ❌ | Not applicable - designed for Vertex AI API calls |
+| Post-tool call | ❌ | Not applicable - only scans final LLM responses |
+| MCP | ❌ | Not applicable - no MCP support |
+
 ## 🎯 What This Does
 
 1. **Client sends prompt** → Apigee gateway

--- a/Kong/custom-plugin/README.md
+++ b/Kong/custom-plugin/README.md
@@ -5,6 +5,19 @@
 
 A Kong Gateway custom plugin that provides real-time security scanning for AI/LLM traffic using Palo Alto Networks Prisma AI Runtime Security.
 
+## Coverage
+
+> For detection categories and use cases, see the [Prisma AIRS documentation](https://pan.dev/prisma-airs/api/airuntimesecurity/usecases/).
+
+| Scanning Phase | Supported | Description |
+|----------------|:---------:|-------------|
+| Prompt | ✅ | Access phase scans user prompts before forwarding to LLM |
+| Response | ✅ | Response phase scans LLM completions before returning to client |
+| Streaming | ❌ | Synchronous scanning with 5-second timeout, requires buffering |
+| Pre-tool call | ❌ | Not implemented - designed for chat completion format |
+| Post-tool call | ❌ | Not implemented - no tool result scanning |
+| MCP | ❌ | Not implemented - no MCP support |
+
 ## Overview
 
 This plugin intercepts LLM API requests and responses, scanning both prompts and completions for security threats before allowing them through. It operates in two phases:

--- a/Kong/request-callout/README.md
+++ b/Kong/request-callout/README.md
@@ -3,6 +3,19 @@
 
 Enterprise-grade AI security scanning for Kong Konnect using PAN.dev AI Runtime Security (AIRS) API. This integration provides real-time threat detection and blocking for AI API requests and responses through Kong's managed cloud platform.
 
+## Coverage
+
+> For detection categories and use cases, see the [Prisma AIRS documentation](https://pan.dev/prisma-airs/api/airuntimesecurity/usecases/).
+
+| Scanning Phase | Supported | Description |
+|----------------|:---------:|-------------|
+| Prompt | ✅ | Request phase scans user prompts before forwarding to AI service |
+| Response | ❌ | Request-side scanning only (see custom-plugin for response scanning) |
+| Streaming | ❌ | Single-phase synchronous scanning only |
+| Pre-tool call | ❌ | Not implemented - designed for API request scanning |
+| Post-tool call | ❌ | Not implemented - no tool result scanning |
+| MCP | ❌ | Not implemented - no MCP support |
+
 ## 🚀 Getting Started
 
 ### What You Need

--- a/LiteLLM/README.md
+++ b/LiteLLM/README.md
@@ -2,6 +2,19 @@
 
 This document provides instructions for configuring Prisma AIRS as a security guardrail within the LiteLLM Proxy (LLM Gateway). This integration enables real-time scanning of prompts and responses to protect against threats like prompt injection, malicious content, and data loss.
 
+## Coverage
+
+> For detection categories and use cases, see the [Prisma AIRS documentation](https://pan.dev/prisma-airs/api/airuntimesecurity/usecases/).
+
+| Scanning Phase | Supported | Description |
+|----------------|:---------:|-------------|
+| Prompt | ✅ | `mode: "pre_call"` scans user input before LLM call |
+| Response | ✅ | `mode: "post_call"` scans LLM output after response |
+| Streaming | ❌ | Guardrails process complete requests/responses only |
+| Pre-tool call | ❌ | Guardrails wrap LLM invocation, not tool calls |
+| Post-tool call | ❌ | Tool/function call scanning not implemented |
+| MCP | ❌ | No MCP integration |
+
 ---
 
 ## Prerequisites

--- a/LiteLLM/README.md
+++ b/LiteLLM/README.md
@@ -10,7 +10,7 @@ This document provides instructions for configuring Prisma AIRS as a security gu
 |----------------|:---------:|-------------|
 | Prompt | ✅ | `mode: "pre_call"` scans user input before LLM call |
 | Response | ✅ | `mode: "post_call"` scans LLM output after response |
-| Streaming | ❌ | Guardrails process complete requests/responses only |
+| Streaming | ⚠️ | Supported for `v1/messages` API signature only |
 | Pre-tool call | ❌ | Guardrails wrap LLM invocation, not tool calls |
 | Post-tool call | ❌ | Tool/function call scanning not implemented |
 | MCP | ❌ | No MCP integration |

--- a/Microsoft/azure-apim/README.md
+++ b/Microsoft/azure-apim/README.md
@@ -2,6 +2,19 @@
 
 A policy fragment that can be integrated into an Azure AI Gateway (part of APIM) as part of a larger AI Gateway policy.
 
+## Coverage
+
+> For detection categories and use cases, see the [Prisma AIRS documentation](https://pan.dev/prisma-airs/api/airuntimesecurity/usecases/).
+
+| Scanning Phase | Supported | Description |
+|----------------|:---------:|-------------|
+| Prompt | ✅ | Scans user prompts in inbound policy before LLM call |
+| Response | ✅ | Scans LLM responses in outbound policy with masking support |
+| Streaming | ❌ | Synchronous scanning with 10-second timeout |
+| Pre-tool call | ❌ | Not applicable - designed for direct LLM gateway requests |
+| Post-tool call | ❌ | Not applicable - only scans user input and LLM responses |
+| MCP | ❌ | Not applicable - no MCP support |
+
 ## 🎯 What This Does
 The fragments handle handles scanning of prompts and responses on the following OpenAI API Calls
 * **POST** Creates a model response for the given chat conversation.

--- a/Portkey/README.md
+++ b/Portkey/README.md
@@ -2,6 +2,19 @@
 
 This document describes how to integrate Prisma AIRS as a security guardrail within the Portkey AI Gateway. This setup allows for the automatic scanning of LLM inputs and outputs to detect and block threats in real-time.
 
+## Coverage
+
+> For detection categories and use cases, see the [Prisma AIRS documentation](https://pan.dev/prisma-airs/api/airuntimesecurity/usecases/).
+
+| Scanning Phase | Supported | Description |
+|----------------|:---------:|-------------|
+| Prompt | ✅ | `input_guardrails` scans prompts before sending to LLM |
+| Response | ✅ | `output_guardrails` scans LLM responses before returning |
+| Streaming | ❌ | Guardrails process complete requests/responses only |
+| Pre-tool call | ❌ | Guardrails intercept at input/output level only |
+| Post-tool call | ❌ | Tool/function result scanning not supported |
+| MCP | ❌ | No MCP scanning |
+
 ---
 
 ## Prerequisites

--- a/TrueFoundry/README.md
+++ b/TrueFoundry/README.md
@@ -10,7 +10,7 @@ This document provides instructions for integrating Prisma AIRS with the TrueFou
 |----------------|:---------:|-------------|
 | Prompt | ✅ | Gateway scans AI requests before forwarding to LLM |
 | Response | ✅ | Gateway validates responses with block/allow actions |
-| Streaming | ❌ | Gateway operates on complete request/response cycles |
+| Streaming | ⚠️ | Supported for `v1/messages` API signature only |
 | Pre-tool call | ❌ | Request and response scanning only |
 | Post-tool call | ❌ | Tool result scanning not documented |
 | MCP | ❌ | No MCP integration |

--- a/TrueFoundry/README.md
+++ b/TrueFoundry/README.md
@@ -2,6 +2,19 @@
 
 This document provides instructions for integrating Prisma AIRS with the TrueFoundry AI Gateway. This integration allows you to use Prisma AIRS as a security guardrail, scanning AI requests and responses for threats directly from the gateway.
 
+## Coverage
+
+> For detection categories and use cases, see the [Prisma AIRS documentation](https://pan.dev/prisma-airs/api/airuntimesecurity/usecases/).
+
+| Scanning Phase | Supported | Description |
+|----------------|:---------:|-------------|
+| Prompt | ✅ | Gateway scans AI requests before forwarding to LLM |
+| Response | ✅ | Gateway validates responses with block/allow actions |
+| Streaming | ❌ | Gateway operates on complete request/response cycles |
+| Pre-tool call | ❌ | Request and response scanning only |
+| Post-tool call | ❌ | Tool result scanning not documented |
+| MCP | ❌ | No MCP integration |
+
 ---
 
 ## Prerequisites

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -2,6 +2,19 @@
 
 This document provides instructions for using the Prisma AIRS community node within n8n to add a layer of security to your automation workflows. This node allows you to scan prompts and responses for threats directly within a workflow.
 
+## Coverage
+
+> For detection categories and use cases, see the [Prisma AIRS documentation](https://pan.dev/prisma-airs/api/airuntimesecurity/usecases/).
+
+| Scanning Phase | Supported | Description |
+|----------------|:---------:|-------------|
+| Prompt | ✅ | "Prompt Scan" operation scans user input for threats |
+| Response | ✅ | "Response Scan" operation scans AI-generated responses |
+| Streaming | ❌ | Node processes complete responses after generation |
+| Pre-tool call | ❌ | Workflow-based - not automatic tool interception |
+| Post-tool call | ❌ | Tool result scanning not implemented |
+| MCP | ❌ | MCP tools in workflows are not scanned by this node |
+
 ---
 
 ## Prerequisites


### PR DESCRIPTION
## Summary                                                                                              

  - Standardize vendor-centric folder structure (`Anthropic/`, `Google/`, `Microsoft/`)
  - Add coverage tables to all 11 integration READMEs showing scanning phase support
  - Update CLAUDE.md with coverage table format specification and icon legend
  - Simplify `.claude/agents.md` to reference CLAUDE.md

  ## Coverage Tables

  Each integration now includes a standardized coverage table:

  | Icon | Meaning |
  |------|---------|
  | ✅ | Full support |
  | ⚠️  | Partial/conditional support |
  | ❌ | No support |

  **Scanning phases tracked:** Prompt, Response, Streaming, Pre-tool call, Post-tool call, MCP
