### PR TITLE
feat(kong): add configurable timeout, debug logging, scan last message

### DIFF
--- a/Kong/custom-plugin/README.md
+++ b/Kong/custom-plugin/README.md
@@ -23,6 +23,8 @@ A Kong Gateway plugin that scans AI/LLM traffic using Prisma AIRS. Supports both
 | `app_name` | No | - | Application identifier (sent as `kong-{app_name}`) |
 | `api_endpoint` | No | `https://service.api.aisecurity.paloaltonetworks.com/v1/scan/sync/request` | AIRS API endpoint |
 | `ssl_verify` | No | `true` | Verify SSL certificates |
+| `timeout_ms` | No | `5000` | AIRS API request timeout in milliseconds |
+| `debug` | No | `false` | Enable debug logging (logs prompts, payloads, responses) |
 
 ## Installation
 
@@ -180,9 +182,8 @@ The plugin fails closed (blocks requests) when:
 
 ## Limitations
 
-- OpenAI chat completion format only
-- Scans first user message in conversation
-- 5-second timeout (hardcoded)
+- OpenAI chat completion format only (Anthropic/Gemini support coming soon)
+- Scans last user message in conversation
 - Response scanning requires response buffering
 
 ## Troubleshooting

--- a/Kong/custom-plugin/schema.lua
+++ b/Kong/custom-plugin/schema.lua
@@ -26,6 +26,8 @@ local schema = {
             },
           },
           { ssl_verify = { type = "boolean", required = true, default = true }, },
+          { timeout_ms = { type = "number", required = false, default = 5000 }, },
+          { debug = { type = "boolean", required = false, default = false }, },
         },
       },
     },


### PR DESCRIPTION
- Bump plugin version to 0.2.0
- Add timeout_ms config option (default 5000ms)
- Add debug config option for verbose logging
- Scan last user message instead of first (fixes multi-turn conversations)
- Update README with new config options

