### PR TITLE
feat(kong): add AI Gateway compatibility for multi-provider support

### DIFF
--- a/Kong/README.md
+++ b/Kong/README.md
@@ -4,10 +4,22 @@ Integrate Kong Gateway with Palo Alto Networks Prisma AI Runtime Security (AIRS)
 
 ## Available Integrations
 
-| Integration | Prompt Scan | Response Scan | Best For |
-|-------------|:-----------:|:-------------:|----------|
-| [Custom Plugin](custom-plugin/) | Yes | Yes | Full coverage, self-managed Kong |
-| [Request Callout](request-callout/) | Yes | No | Kong Konnect SaaS, no custom code |
+| Integration | Prompt Scan | Response Scan | Multi-Provider | Best For |
+|-------------|:-----------:|:-------------:|:--------------:|----------|
+| [Custom Plugin](custom-plugin/) | ✅ | ✅ | ✅ (via AI Gateway) | Full coverage, any provider |
+| [Request Callout](request-callout/) | ✅ | ❌ | ❌ | Kong Konnect SaaS, OpenAI only |
+
+### Multi-Provider Support
+
+The custom plugin supports all LLM providers when used with [Kong AI Gateway](https://developer.konghq.com/ai-gateway/):
+
+- OpenAI / Azure OpenAI
+- Anthropic Claude
+- Google Gemini / Vertex AI
+- AWS Bedrock
+- Mistral, Cohere, and more
+
+Kong's AI Proxy plugin normalizes requests/responses to OpenAI format. See [custom-plugin README](custom-plugin/README.md#multi-provider-support-kong-ai-gateway) for setup.
 
 ## Quick Start
 

--- a/Kong/custom-plugin/handler.lua
+++ b/Kong/custom-plugin/handler.lua
@@ -4,8 +4,8 @@ local http = require("resty.http")
 local cjson = require("cjson")
 
 local SecurePrismaAIRSHandler = {
-  PRIORITY = 1000,
-  VERSION = "0.2.0",
+  PRIORITY = 760,  -- Below ai-proxy (770) for AI Gateway response phase compatibility
+  VERSION = "0.3.0",
 }
 
 -- A dedicated, protected function for logging errors safely.


### PR DESCRIPTION
- Change plugin priority from 1000 to 760 (below ai-proxy at 770)
- Ensures response phase runs after AI Proxy transforms to OpenAI format
- Add Multi-Provider Support section to custom-plugin README
- Document AI Gateway setup with AI Proxy plugin
- Update parent README with multi-provider comparison table
- Bump version to 0.3.0
