### PR TITLE
feat(anthropic): standardize env vars and enhance Claude Code skill

### DIFF
--- a/Anthropic/claude-code-hooks/README.md
+++ b/Anthropic/claude-code-hooks/README.md
@@ -147,8 +147,10 @@ chmod +x *.sh
 
 2. **Configure Environment**
 ```bash
-export AIRS_API_KEY="your-prisma-airs-token"
-export PROFILE_NAME="your-security-profile"  
+export PRISMA_AIRS_API_KEY="your-prisma-airs-api-key"
+export PRISMA_AIRS_PROFILE_NAME="your-security-profile"
+# Optional: Regional endpoint (default is US)
+# export PRISMA_AIRS_URL="https://service-de.api.aisecurity.paloaltonetworks.com"  # EU
 ```
 
 3. **Configure Claude Code Hooks** (in `.claude/claude_config.yaml`):
@@ -183,9 +185,10 @@ Control detection sensitivity via Prisma AIRS profiles:
 - **`audit-only-profile`**: Log threats without blocking (monitoring mode)
 
 ### Customizing Detection
+
+Set your security profile via environment variable:
 ```bash
-# In each hook file, modify:
-PROFILE_NAME="your-custom-profile"
+export PRISMA_AIRS_PROFILE_NAME="your-custom-profile"
 ```
 
 ### Log Configuration

--- a/Anthropic/claude-code-hooks/example.env
+++ b/Anthropic/claude-code-hooks/example.env
@@ -2,18 +2,20 @@
 # Add these to your shell profile (.bashrc, .zshrc, etc.)
 
 # Prisma AIRS API Key (REQUIRED)
-# Get this from Strata Cloud Manager
-export AIRS_API_KEY="your-airs-api-key-here"
+# Get this from Strata Cloud Manager > AI Runtime Security > API Intercept
+export PRISMA_AIRS_API_KEY="your-airs-api-key-here"
 
-# Prisma AIRS Profile Name or Profile ID (REQUIRED)  
-# Create this profile in Strata Cloud Manager
-export AIRS_PROFILE_NAME="your-profile-name"
+# Prisma AIRS Profile Name (REQUIRED)
+# Create this profile in Strata Cloud Manager > AI Runtime Security > Security Profiles
+export PRISMA_AIRS_PROFILE_NAME="your-profile-name"
 
-# Optional: Custom AIRS API endpoint (for different regions)
-# Default: US endpoint
-# export AIRS_API_URL="https://service-de.api.aisecurity.paloaltonetworks.com/v1/scan/sync/request"  # EU
-# export AIRS_API_URL="https://service-in.api.aisecurity.paloaltonetworks.com/v1/scan/sync/request"  # India
+# Optional: Custom AIRS API endpoint base URL (for different regions)
+# Note: Provide base URL only - the API path is appended automatically
+# Default: US endpoint (https://service.api.aisecurity.paloaltonetworks.com)
+# export PRISMA_AIRS_URL="https://service-de.api.aisecurity.paloaltonetworks.com"  # EU
+# export PRISMA_AIRS_URL="https://service-in.api.aisecurity.paloaltonetworks.com"  # India
+# export PRISMA_AIRS_URL="https://service-sg.api.aisecurity.paloaltonetworks.com"  # Singapore
 
 # Optional: Custom security log location
-# Default: ".claude/hooks/security.log"  
+# Default: ".claude/hooks/security.log"
 # export SECURITY_LOG_PATH="/custom/path/to/security.log"

--- a/Anthropic/claude-code-hooks/hooks/scan-mcp-request.sh
+++ b/Anthropic/claude-code-hooks/hooks/scan-mcp-request.sh
@@ -2,9 +2,10 @@
 
 # Configuration with environment variable support
 LOG_FILE="${SECURITY_LOG_PATH:-.claude/hooks/security.log}"
-AIRS_API_URL="${AIRS_API_URL:-https://service.api.aisecurity.paloaltonetworks.com/v1/scan/sync/request}"
-AIRS_API_KEY="${AIRS_API_KEY}"
-PROFILE_NAME="${AIRS_PROFILE_NAME}"
+AIRS_BASE_URL="${PRISMA_AIRS_URL:-https://service.api.aisecurity.paloaltonetworks.com}"
+AIRS_API_URL="${AIRS_BASE_URL%/}/v1/scan/sync/request"
+AIRS_API_KEY="${PRISMA_AIRS_API_KEY}"
+PROFILE_NAME="${PRISMA_AIRS_PROFILE_NAME}"
 
 # Create log file if it doesn't exist
 mkdir -p "$(dirname "$LOG_FILE")"
@@ -12,12 +13,12 @@ touch "$LOG_FILE"
 
 # Check if required environment variables are configured
 if [[ -z "$AIRS_API_KEY" ]]; then
-    echo "[$(date)] ERROR: AIRS_API_KEY environment variable not set" >> "$LOG_FILE"
+    echo "[$(date)] ERROR: PRISMA_AIRS_API_KEY environment variable not set" >> "$LOG_FILE"
     exit 0  # Allow but log error
 fi
 
 if [[ -z "$PROFILE_NAME" ]]; then
-    echo "[$(date)] ERROR: AIRS_PROFILE_NAME environment variable not set" >> "$LOG_FILE"
+    echo "[$(date)] ERROR: PRISMA_AIRS_PROFILE_NAME environment variable not set" >> "$LOG_FILE"
     exit 0  # Allow but log error
 fi
 

--- a/Anthropic/claude-code-hooks/hooks/scan-response-enhanced.sh
+++ b/Anthropic/claude-code-hooks/hooks/scan-response-enhanced.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-LOG_FILE="/Users/jpro/demos/cc_hooks/.claude/hooks/security.log"
-
-# Prisma AIRS API Configuration
-AIRS_API_URL="https://service.api.aisecurity.paloaltonetworks.com/v1/scan/sync/request"
-AIRS_API_KEY="${AIRS_API_KEY}"
-PROFILE_NAME="dev-block-all-profile"
+# Configuration with environment variable support
+LOG_FILE="${SECURITY_LOG_PATH:-.claude/hooks/security.log}"
+AIRS_BASE_URL="${PRISMA_AIRS_URL:-https://service.api.aisecurity.paloaltonetworks.com}"
+AIRS_API_URL="${AIRS_BASE_URL%/}/v1/scan/sync/request"
+AIRS_API_KEY="${PRISMA_AIRS_API_KEY}"
+PROFILE_NAME="${PRISMA_AIRS_PROFILE_NAME}"
 
 # === FD HARDENING FOR CLEAN JSON OUTPUT ===
 # Save original stdout to FD 3 for JSON responses
@@ -15,7 +15,7 @@ exec 1>>"$LOG_FILE"
 # Keep stderr available for user messages (shows in terminal Claude Code)
 
 # Create log file if it doesn't exist
-mkdir -p "/Users/jpro/demos/cc_hooks/.claude/hooks"
+mkdir -p "$(dirname "$LOG_FILE")"
 touch "$LOG_FILE"
 
 # Read JSON input from stdin
@@ -71,7 +71,7 @@ if [[ -z "$RESPONSE_CONTENT" || ${#RESPONSE_CONTENT} -lt 5 ]]; then
 fi
 
 # Fail-closed guard for API key
-: "${AIRS_API_KEY:?AIRS_API_KEY not set}"
+: "${AIRS_API_KEY:?PRISMA_AIRS_API_KEY not set}"
 
 # Extract URLs from response content with better regex
 URLS=$(echo "$RESPONSE_CONTENT" | grep -oE 'https?://[^\s<>"'"'"'()]+' | sort -u)

--- a/Anthropic/claude-code-hooks/hooks/scan-url.sh
+++ b/Anthropic/claude-code-hooks/hooks/scan-url.sh
@@ -5,9 +5,10 @@
 
 # Configuration with environment variable support
 LOG_FILE="${SECURITY_LOG_PATH:-.claude/hooks/security.log}"
-AIRS_API_URL="${AIRS_API_URL:-https://service.api.aisecurity.paloaltonetworks.com/v1/scan/sync/request}"
-AIRS_API_KEY="${AIRS_API_KEY}"
-PROFILE_NAME="${AIRS_PROFILE_NAME}"
+AIRS_BASE_URL="${PRISMA_AIRS_URL:-https://service.api.aisecurity.paloaltonetworks.com}"
+AIRS_API_URL="${AIRS_BASE_URL%/}/v1/scan/sync/request"
+AIRS_API_KEY="${PRISMA_AIRS_API_KEY}"
+PROFILE_NAME="${PRISMA_AIRS_PROFILE_NAME}"
 
 # Create log file if it doesn't exist
 mkdir -p "$(dirname "$LOG_FILE")"
@@ -15,12 +16,12 @@ touch "$LOG_FILE"
 
 # Check if required environment variables are configured
 if [[ -z "$AIRS_API_KEY" ]]; then
-    echo "[$(date)] ERROR: AIRS_API_KEY environment variable not set" >> "$LOG_FILE"
+    echo "[$(date)] ERROR: PRISMA_AIRS_API_KEY environment variable not set" >> "$LOG_FILE"
     exit 0  # Allow but log error
 fi
 
 if [[ -z "$PROFILE_NAME" ]]; then
-    echo "[$(date)] ERROR: AIRS_PROFILE_NAME environment variable not set" >> "$LOG_FILE"
+    echo "[$(date)] ERROR: PRISMA_AIRS_PROFILE_NAME environment variable not set" >> "$LOG_FILE"
     exit 0  # Allow but log error
 fi
 

--- a/Anthropic/claude-code-hooks/hooks/scan-user-input.sh
+++ b/Anthropic/claude-code-hooks/hooks/scan-user-input.sh
@@ -6,9 +6,10 @@
 
 # Configuration with environment variable support
 LOG_FILE="${SECURITY_LOG_PATH:-.claude/hooks/security.log}"
-AIRS_API_URL="${AIRS_API_URL:-https://service.api.aisecurity.paloaltonetworks.com/v1/scan/sync/request}"
-AIRS_API_KEY="${AIRS_API_KEY}"
-PROFILE_NAME="${AIRS_PROFILE_NAME}"
+AIRS_BASE_URL="${PRISMA_AIRS_URL:-https://service.api.aisecurity.paloaltonetworks.com}"
+AIRS_API_URL="${AIRS_BASE_URL%/}/v1/scan/sync/request"
+AIRS_API_KEY="${PRISMA_AIRS_API_KEY}"
+PROFILE_NAME="${PRISMA_AIRS_PROFILE_NAME}"
 
 # Create log file if it doesn't exist
 mkdir -p "$(dirname "$LOG_FILE")"
@@ -16,12 +17,12 @@ touch "$LOG_FILE"
 
 # Check if required environment variables are configured
 if [[ -z "$AIRS_API_KEY" ]]; then
-    echo "[$(date)] ERROR: AIRS_API_KEY environment variable not set" >> "$LOG_FILE"
+    echo "[$(date)] ERROR: PRISMA_AIRS_API_KEY environment variable not set" >> "$LOG_FILE"
     exit 0  # Allow but log error
 fi
 
 if [[ -z "$PROFILE_NAME" ]]; then
-    echo "[$(date)] ERROR: AIRS_PROFILE_NAME environment variable not set" >> "$LOG_FILE"
+    echo "[$(date)] ERROR: PRISMA_AIRS_PROFILE_NAME environment variable not set" >> "$LOG_FILE"
     exit 0  # Allow but log error
 fi
 

--- a/Anthropic/claude-code-mcp/README.md
+++ b/Anthropic/claude-code-mcp/README.md
@@ -43,8 +43,8 @@ The Prisma AIRS MCP Server provides Claude Code with security scanning tools via
 Add to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
 
 ```bash
-export PAN_TOKEN="your-prisma-airs-api-key"
-export PAN_PROFILE="your-security-profile-name"  # Optional
+export PRISMA_AIRS_API_KEY="your-prisma-airs-api-key"
+export PRISMA_AIRS_PROFILE_NAME="your-security-profile-name"
 ```
 
 ### MCP Server Configuration
@@ -69,8 +69,8 @@ Edit `~/.claude.json` and add the `mcpServers` section:
       "type": "http",
       "url": "https://service.api.aisecurity.paloaltonetworks.com/mcp",
       "headers": {
-        "x-pan-token": "${PAN_TOKEN}",
-        "x-pan-profile": "${PAN_PROFILE}"
+        "x-pan-token": "${PRISMA_AIRS_API_KEY}",
+        "x-pan-profile": "${PRISMA_AIRS_PROFILE_NAME}"
       }
     }
   }
@@ -88,15 +88,15 @@ Create or edit `.claude/settings.json` in your project root:
       "type": "http",
       "url": "https://service.api.aisecurity.paloaltonetworks.com/mcp",
       "headers": {
-        "x-pan-token": "${PAN_TOKEN}",
-        "x-pan-profile": "${PAN_PROFILE}"
+        "x-pan-token": "${PRISMA_AIRS_API_KEY}",
+        "x-pan-profile": "${PRISMA_AIRS_PROFILE_NAME}"
       }
     }
   }
 }
 ```
 
-> **Note:** Environment variables (`${PAN_TOKEN}`) are resolved at runtime. Team members set their own credentials via environment variables.
+> **Note:** Environment variables (`${PRISMA_AIRS_API_KEY}`) are resolved at runtime. Team members set their own credentials via environment variables.
 
 ---
 
@@ -149,7 +149,7 @@ Claude will invoke the MCP tool automatically.
 
 ### Server Not Appearing
 
-- Verify environment variables are set: `echo $PAN_TOKEN`
+- Verify environment variables are set: `echo $PRISMA_AIRS_API_KEY`
 - Check JSON syntax in config file
 - Restart Claude Code after config changes
 

--- a/Anthropic/claude-code-skill/.env.example
+++ b/Anthropic/claude-code-skill/.env.example
@@ -7,9 +7,11 @@ PRISMA_AIRS_API_KEY=your-api-key-here
 
 # Required: Security profile name
 # Find in: AI Runtime Security > Security Profiles
-PRISMA_AIRS_PROFILE=default
+PRISMA_AIRS_PROFILE_NAME=default
 
-# Optional: API endpoint
+# Optional: API endpoint (base URL without path)
 # US (default): https://service.api.aisecurity.paloaltonetworks.com
-# EU: https://eu.service.api.aisecurity.paloaltonetworks.com
-# PRISMA_AIRS_ENDPOINT=https://service.api.aisecurity.paloaltonetworks.com
+# EU: https://service-de.api.aisecurity.paloaltonetworks.com
+# India: https://service-in.api.aisecurity.paloaltonetworks.com
+# Singapore: https://service-sg.api.aisecurity.paloaltonetworks.com
+# PRISMA_AIRS_URL=https://service.api.aisecurity.paloaltonetworks.com

--- a/Anthropic/claude-code-skill/README.md
+++ b/Anthropic/claude-code-skill/README.md
@@ -41,9 +41,11 @@ Add the following to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
 
 ```bash
 export PRISMA_AIRS_API_KEY="your-api-key-here"
-export PRISMA_AIRS_PROFILE="your-profile-name"
-# Optional: EU endpoint
-# export PRISMA_AIRS_ENDPOINT="https://eu.service.api.aisecurity.paloaltonetworks.com"
+export PRISMA_AIRS_PROFILE_NAME="your-profile-name"
+# Optional: Regional endpoints
+# export PRISMA_AIRS_URL="https://service-de.api.aisecurity.paloaltonetworks.com"  # EU
+# export PRISMA_AIRS_URL="https://service-in.api.aisecurity.paloaltonetworks.com"  # India
+# export PRISMA_AIRS_URL="https://service-sg.api.aisecurity.paloaltonetworks.com"  # Singapore
 ```
 
 Or copy the environment template:
@@ -66,34 +68,30 @@ source .env
 ### As a Slash Command
 
 ```
-/airs-scan
+/prisma-airs
 ```
 
-Claude will automatically invoke this skill when appropriate based on the context.
+Claude will also automatically invoke this skill when appropriate based on context (e.g., when generating security-sensitive code or handling user input).
 
-### Manual Invocation
+### Input Methods
+
+The scanner accepts content via three methods:
 
 ```bash
-# Scan a prompt
-python ~/.claude/skills/prisma-airs-skill/scripts/scan.py \
-  --type prompt \
-  --content "user input to scan"
+# Method 1: Heredoc (recommended - handles quotes and newlines)
+python scripts/scan.py --type prompt <<'EOF'
+Content with "quotes" and
+multiple lines works fine.
+EOF
 
-# Scan code from a file
-python ~/.claude/skills/prisma-airs-skill/scripts/scan.py \
-  --type code \
-  --file path/to/generated-code.py
+# Method 2: File (recommended for code)
+python scripts/scan.py --type code --file path/to/file.py
 
-# Scan AI response
-python ~/.claude/skills/prisma-airs-skill/scripts/scan.py \
-  --type response \
-  --content "AI generated response"
+# Method 3: Direct argument (simple content only)
+python scripts/scan.py --type prompt --content "simple text"
 
-# Scan conversation (prompt + response)
-python ~/.claude/skills/prisma-airs-skill/scripts/scan.py \
-  --type conversation \
-  --prompt "user prompt" \
-  --response "AI response"
+# Conversation (prompt + response together)
+python scripts/scan.py --type conversation --prompt "user" --response "ai"
 ```
 
 ## Scan Types
@@ -109,19 +107,16 @@ python ~/.claude/skills/prisma-airs-skill/scripts/scan.py \
 
 ```json
 {
-  "status": "safe|threat_detected|error",
+  "status": "safe|threat_detected|blocked",
   "action": "allow|block|alert",
-  "threats": [
-    {
-      "category": "prompt_injection",
-      "severity": "high",
-      "location": "prompt",
-      "description": "Potential prompt injection attack detected"
-    }
-  ],
-  "scan_id": "unique-identifier"
+  "category": "benign|malicious",
+  "scan_id": "unique-identifier",
+  "prompt_detected": ["injection", "dlp"],
+  "response_detected": ["toxic_content"]
 }
 ```
+
+Use `--verbose` to include the full AIRS API response.
 
 ## Exit Codes
 


### PR DESCRIPTION
- Standardize environment variables across all Claude Code integrations:
  - PRISMA_AIRS_API_KEY
  - PRISMA_AIRS_PROFILE_NAME
  - PRISMA_AIRS_URL

- Enhance Claude Code skill (SKILL.md):
  - Add directive description for better auto-triggering
  - Add stdin/heredoc support for complex content
  - Document three input methods (heredoc, file, argument)
  - Rename skill from airs-scan to prisma-airs

- Fix scan.py:
  - Add stdin support for heredoc pattern
  - Add app_name metadata per CLAUDE.md requirements
  - Simplify parse_response to pass through AIRS response
  - Fix bug where "error": false was treated as error
  - Remove debug print statement

- Update hooks to use base URL + append path pattern
- Fix hardcoded paths in scan-response-enhanced.sh
