### PR TITLE
feat(anthropic): standardize app_name across Claude Code integrations

### DIFF
--- a/Anthropic/claude-code-hooks/hooks/scan-mcp-request.sh
+++ b/Anthropic/claude-code-hooks/hooks/scan-mcp-request.sh
@@ -67,7 +67,7 @@ PAYLOAD=$(cat << EOF
   },
   "metadata": {
     "app_user": "claude-code-user",
-    "app_name": "Claude Code",
+    "app_name": "claude-code-hook",
     "ai_model": "sonnet",
     "source": "mcp-request",
     "tool_name": "$TOOL_NAME"

--- a/Anthropic/claude-code-hooks/hooks/scan-user-input.sh
+++ b/Anthropic/claude-code-hooks/hooks/scan-user-input.sh
@@ -46,7 +46,7 @@ PAYLOAD=$(cat << EOF
   },
   "metadata": {
     "app_user": "claude-code-user",
-    "app_name": "Claude Code",
+    "app_name": "claude-code-hook",
     "ai_model": "sonnet",
     "source": "user-prompt-submit"
   },

--- a/Anthropic/claude-code-mcp/README.md
+++ b/Anthropic/claude-code-mcp/README.md
@@ -134,6 +134,22 @@ Scan this code for security issues using Prisma AIRS:
 
 Claude will invoke the MCP tool automatically.
 
+### app_name Parameter
+
+When invoking the MCP tools, use `app_name: "claude-code-mcp"` to identify scans from the MCP integration:
+
+```json
+{
+  "prompt": "content to scan",
+  "app_name": "claude-code-mcp"
+}
+```
+
+This distinguishes MCP scans from other Claude Code integrations:
+- `claude-code-hook` - Hooks integration
+- `claude-code-skill` - Skill integration
+- `claude-code-mcp` - MCP integration
+
 ---
 
 ## Verification


### PR DESCRIPTION
Use distinct app_name values to identify the source integration:
- claude-code-hook: Hooks integration
- claude-code-skill: Skill integration (already correct)
- claude-code-mcp: MCP integration

