### PR TITLE
feat(apigee): standardize env vars to PRISMA_AIRS_* naming

### DIFF
--- a/Google/apigee/ARCHITECTURE.md
+++ b/Google/apigee/ARCHITECTURE.md
@@ -36,8 +36,8 @@ This deployment uses Apigee's **modern, recommended pattern** where:
 │  │ PREFLOW (Request Pipeline)                              │    │
 │  │                                                         │    │
 │  │ 1. [KVM-GetConfig]                                       │  │
-│  │    ├─ private.airs.token                                 │  │
-│  │    ├─ private.airs.profile                               │  │
+│  │    ├─ private.prisma.airs.token                                 │  │
+│  │    ├─ private.prisma.airs.profile                               │  │
 │  │    ├─ private.vertex.project                             │  │
 │  │    └─ private.vertex.model                               │  │
 │  │                                                          │  │
@@ -45,7 +45,7 @@ This deployment uses Apigee's **modern, recommended pattern** where:
 │  │    Extract prompt & build AIRS payload              │    │  │
 │  │                                                     │    │  │
 │  │ 3. [AM-AIRSRequest]                                 │    │  │
-│  │    Set X-Pan-Token: {private.airs.token}            │    │  │
+│  │    Set X-Pan-Token: {private.prisma.airs.token}            │    │  │
 │  │                                                     │    │  │
 │  │ 4. [SC-AIRSScan] ────────────────────────┐          │    │  │
 │  │    POST /v1/scan/sync/request            │          │    │  │
@@ -88,7 +88,7 @@ This deployment uses Apigee's **modern, recommended pattern** where:
 │  │    Extract response & build AIRS payload             │  │  │
 │  │                                                      │  │  │
 │  │ 9. [AM-AIRSResponseRequest]                          │  │  │
-│  │    Set X-Pan-Token: {private.airs.token              │  │  │
+│  │    Set X-Pan-Token: {private.prisma.airs.token              │  │  │
 │  │                                                      │  │  │
 │  │ 10. [SC-AIRSResponseScan] ──────────────┐            │  │  │
 │  │     POST /v1/scan/sync/request          │            │  │  │
@@ -172,8 +172,8 @@ LEGEND:
 │  │  Encrypted KVM   │                           │ Google Auth  │ │
 │  │  (private)       │                           │ (OAuth 2.0)  │ │
 │  │                  │                           │              │ │
-│  │ • airs.token     │                           │ Auto-gen     │ │
-│  │ • airs.profile   │                           │ token for    │ │
+│  │ • prisma.airs.token     │                           │ Auto-gen     │ │
+│  │ • prisma.airs.profile   │                           │ token for    │ │
 │  │ • vertex.project │                           │ Vertex AI    │ │
 │  │ • vertex.model   │                           │              │ │
 │  └──────────────────┘                           └──────────────┘ │
@@ -454,7 +454,7 @@ KEY POINTS:
    - Token auto-generated per request
 
 2. **Apigee → Prisma AIRS**: X-Pan-Token header
-   - Stored in encrypted KVM: `airs.token`
+   - Stored in encrypted KVM: `prisma.airs.token`
    - Retrieved once per request in PreFlow
    - Used for both prompt and response scans
 

--- a/Google/apigee/README.md
+++ b/Google/apigee/README.md
@@ -66,7 +66,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for detailed Mermaid diagrams showing:
 cp .env.sample .env
 # Edit .env with your values:
 # - APIGEE_ORG, APIGEE_ENV
-# - PANW_PRISMA_AIRS_API_KEY
+# - PRISMA_AIRS_API_KEY, PRISMA_AIRS_PROFILE_NAME, PRISMA_AIRS_URL
 # - GOOGLE_CLOUD_PROJECT
 ```
 
@@ -121,8 +121,11 @@ APIGEE_ORG="your-apigee-org"
 APIGEE_ENV="eval"  # or test, prod
 
 # Prisma AIRS Configuration
-PANW_PRISMA_AIRS_API_KEY="your-airs-api-key"
-AIRS_API_PROFILE_NAME="your-profile-name"
+PRISMA_AIRS_API_KEY="your-airs-api-key"
+PRISMA_AIRS_PROFILE_NAME="your-profile-name"
+# Regional endpoints (uncomment one):
+PRISMA_AIRS_URL="https://service.api.aisecurity.paloaltonetworks.com"        # US (default)
+# PRISMA_AIRS_URL="https://service.api.eu.aisecurity.paloaltonetworks.com"   # EU
 
 # GCP/Vertex AI Configuration
 GOOGLE_CLOUD_PROJECT="your-gcp-project"
@@ -135,8 +138,9 @@ GOOGLE_APPLICATION_CREDENTIALS="/path/to/sa.json"
 ### KVM Entries (Auto-Created by deploy.sh)
 
 The deployment script creates an encrypted KVM named `private` with:
-- `airs.token` - Your Prisma AIRS API key
-- `airs.profile` - AIRS profile name
+- `prisma.airs.token` - Your Prisma AIRS API key
+- `prisma.airs.profile` - AIRS profile name
+- `prisma.airs.url` - AIRS API endpoint
 - `vertex.project` - GCP project ID
 - `vertex.model` - Vertex AI model name
 

--- a/Google/apigee/apiproxy/policies/AM-AIRSRequest.xml
+++ b/Google/apigee/apiproxy/policies/AM-AIRSRequest.xml
@@ -3,7 +3,7 @@
   <Set>
     <Headers>
       <Header name="Content-Type">application/json</Header>
-      <Header name="X-Pan-Token">{private.airs.token}</Header>
+      <Header name="X-Pan-Token">{private.prisma.airs.token}</Header>
     </Headers>
     <Payload contentType="application/json">{airs.request.payload}</Payload>
     <Verb>POST</Verb>

--- a/Google/apigee/apiproxy/policies/AM-AIRSResponseRequest.xml
+++ b/Google/apigee/apiproxy/policies/AM-AIRSResponseRequest.xml
@@ -3,7 +3,7 @@
   <Set>
     <Headers>
       <Header name="Content-Type">application/json</Header>
-      <Header name="X-Pan-Token">{private.airs.token}</Header>
+      <Header name="X-Pan-Token">{private.prisma.airs.token}</Header>
     </Headers>
     <Payload contentType="application/json">{airs.scan.response.payload}</Payload>
     <Verb>POST</Verb>

--- a/Google/apigee/apiproxy/policies/KVM-GetConfig.xml
+++ b/Google/apigee/apiproxy/policies/KVM-GetConfig.xml
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <KeyValueMapOperations name="KVM-GetConfig" mapIdentifier="private">
   <Scope>environment</Scope>
-  <Get assignTo="private.airs.token">
+  <Get assignTo="private.prisma.airs.token">
     <Key>
-      <Parameter>airs.token</Parameter>
+      <Parameter>prisma.airs.token</Parameter>
     </Key>
   </Get>
-  <Get assignTo="private.airs.profile">
+  <Get assignTo="private.prisma.airs.profile">
     <Key>
-      <Parameter>airs.profile</Parameter>
+      <Parameter>prisma.airs.profile</Parameter>
+    </Key>
+  </Get>
+  <Get assignTo="private.prisma.airs.url">
+    <Key>
+      <Parameter>prisma.airs.url</Parameter>
     </Key>
   </Get>
   <Get assignTo="private.vertex.project">

--- a/Google/apigee/apiproxy/policies/SC-AIRSResponseScan.xml
+++ b/Google/apigee/apiproxy/policies/SC-AIRSResponseScan.xml
@@ -4,7 +4,7 @@
   <Response>airs.scan.response.result</Response>
   <Timeout>5000</Timeout>
   <HTTPTargetConnection>
-    <URL>https://service.api.aisecurity.paloaltonetworks.com/v1/scan/sync/request</URL>
+    <URL>{private.prisma.airs.url}/v1/scan/sync/request</URL>
   </HTTPTargetConnection>
 </ServiceCallout>
 

--- a/Google/apigee/apiproxy/policies/SC-AIRSScan.xml
+++ b/Google/apigee/apiproxy/policies/SC-AIRSScan.xml
@@ -4,6 +4,6 @@
   <Response>airs.response</Response>
   <Timeout>5000</Timeout>
   <HTTPTargetConnection>
-    <URL>https://service.api.aisecurity.paloaltonetworks.com/v1/scan/sync/request</URL>
+    <URL>{private.prisma.airs.url}/v1/scan/sync/request</URL>
   </HTTPTargetConnection>
 </ServiceCallout>

--- a/Google/apigee/apiproxy/resources/jsc/scan-prompt.js
+++ b/Google/apigee/apiproxy/resources/jsc/scan-prompt.js
@@ -22,7 +22,7 @@ try {
 
 // Build AIRS scan payload
 var sessionId = context.getVariable('request.header.X-Session-ID') || context.getVariable('messageid');
-var airsProfile = context.getVariable('request.header.X-Pan-Profile') || context.getVariable('private.airs.profile') || 'default';
+var airsProfile = context.getVariable('request.header.X-Pan-Profile') || context.getVariable('private.prisma.airs.profile') || 'default';
 var vertexModel = context.getVariable('private.vertex.model') || 'gemini-2.5-flash';
 
 var payload = {

--- a/Google/apigee/apiproxy/resources/jsc/scan-response.js
+++ b/Google/apigee/apiproxy/resources/jsc/scan-response.js
@@ -22,7 +22,7 @@ try {
 
 // Build AIRS scan payload
 var sessionId = context.getVariable('request.header.X-Session-ID') || context.getVariable('messageid');
-var airsProfile = context.getVariable('request.header.X-Pan-Profile') || context.getVariable('private.airs.profile') || 'default';
+var airsProfile = context.getVariable('request.header.X-Pan-Profile') || context.getVariable('private.prisma.airs.profile') || 'default';
 var vertexModel = context.getVariable('private.vertex.model') || 'gemini-2.5-flash';
 
 var payload = {

--- a/Google/apigee/example.env
+++ b/Google/apigee/example.env
@@ -3,8 +3,11 @@ APIGEE_ORG="your-apigee-org"
 APIGEE_ENV="eval"  # or test, prod
 
 # Prisma AIRS Configuration
-PANW_PRISMA_AIRS_API_KEY="your-airs-api-key-here"
-AIRS_API_PROFILE_NAME="default"
+PRISMA_AIRS_API_KEY="your-airs-api-key-here"
+PRISMA_AIRS_PROFILE_NAME="your-profile-name"
+# Regional endpoints (uncomment one):
+PRISMA_AIRS_URL="https://service.api.aisecurity.paloaltonetworks.com"        # US (default)
+# PRISMA_AIRS_URL="https://service.api.eu.aisecurity.paloaltonetworks.com"   # EU
 
 # GCP/Vertex AI Configuration
 GOOGLE_CLOUD_PROJECT="your-gcp-project-id"


### PR DESCRIPTION
- Rename env vars: PANW_PRISMA_AIRS_API_KEY -> PRISMA_AIRS_API_KEY, AIRS_API_PROFILE_NAME -> PRISMA_AIRS_PROFILE_NAME
- Add PRISMA_AIRS_URL as configurable env var (removes hardcoded URL)
- Update KVM keys to prisma.airs.* naming throughout
- Update flow variables to private.prisma.airs.* in all policies
- Add profile validation (no default assumption)
- Replace emoji output with text labels in deploy.sh
- Document regional endpoints (US/EU) in example.env and README

