### PR TITLE
docs: remove MCP column from Coverage tables

### DIFF
--- a/Anthropic/claude-code-hooks/README.md
+++ b/Anthropic/claude-code-hooks/README.md
@@ -15,7 +15,6 @@ A comprehensive defense-in-depth security framework that protects Claude Code in
 | Streaming | ❌ | Not implemented - processes complete responses only |
 | Pre-tool call | ✅ | Scans MCP tool parameters and URLs via `PreToolUse` hook |
 | Post-tool call | ✅ | Scans tool responses from MCP and WebFetch via `PostToolUse` hook |
-| MCP | ✅ | Advanced MCP scanning with regex-based tool matching |
 
 ## 🛡️ Executive Summary
 

--- a/Anthropic/claude-code-mcp/README.md
+++ b/Anthropic/claude-code-mcp/README.md
@@ -13,7 +13,6 @@ Connect Claude Code to Prisma AIRS via the Model Context Protocol (MCP) for on-d
 | Streaming | ❌ | MCP tools are blocking synchronous calls |
 | Pre-tool call | ❌ | Not automatic - Claude must explicitly invoke scanning |
 | Post-tool call | ❌ | Not automatic - Claude must explicitly invoke scanning |
-| MCP | ❌ | Provides MCP tools but does not intercept MCP interactions |
 
 ## Overview
 

--- a/Anthropic/claude-code-skill/README.md
+++ b/Anthropic/claude-code-skill/README.md
@@ -13,7 +13,6 @@ A Claude Code skill that integrates Palo Alto Networks Prisma AI Runtime Securit
 | Streaming | ❌ | Synchronous blocking scan only |
 | Pre-tool call | ❌ | Not designed for pre-tool validation |
 | Post-tool call | ❌ | Not designed for post-tool validation |
-| MCP | ❌ | Not designed for MCP interactions |
 
 ## Features
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,6 @@ Every integration README must include a Coverage section after the title/descrip
 | Streaming | ❌ | Real-time scanning of streamed responses |
 | Pre-tool call | ❌ | Scans before tool/function execution |
 | Post-tool call | ❌ | Scans tool/function results |
-| MCP | ❌ | Scans Model Context Protocol interactions |
 ```
 
 **Support icons:**
@@ -54,7 +53,6 @@ Every integration README must include a Coverage section after the title/descrip
 - **Streaming**: Real-time scanning of streamed LLM responses
 - **Pre-tool**: Scans before tool/function calls are executed
 - **Post-tool**: Scans results returned from tool/function calls
-- **MCP**: Scans Model Context Protocol server/tool interactions
 
 ## Working in This Repo
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,6 @@ Brief description of what this integration does.
 | Streaming | ❌ | Real-time scanning of streamed responses |
 | Pre-tool call | ❌ | Scans before tool/function execution |
 | Post-tool call | ❌ | Scans tool/function results |
-| MCP | ❌ | Scans Model Context Protocol interactions |
 
 **Legend:** ✅ Full support | ⚠️ Partial support | ❌ Not supported
 

--- a/Google/apigee/README.md
+++ b/Google/apigee/README.md
@@ -15,7 +15,6 @@ A production-ready Apigee X proxy that integrates **Prisma AIRS security scannin
 | Streaming | ❌ | Synchronous ServiceCallout with 5-second timeout |
 | Pre-tool call | ❌ | Not applicable - designed for Vertex AI API calls |
 | Post-tool call | ❌ | Not applicable - only scans final LLM responses |
-| MCP | ❌ | Not applicable - no MCP support |
 
 ## 🎯 What This Does
 

--- a/LiteLLM/README.md
+++ b/LiteLLM/README.md
@@ -13,7 +13,6 @@ This document provides instructions for configuring Prisma AIRS as a security gu
 | Streaming | ⚠️ | Supported for `v1/messages` API signature only |
 | Pre-tool call | ❌ | Guardrails wrap LLM invocation, not tool calls |
 | Post-tool call | ❌ | Tool/function call scanning not implemented |
-| MCP | ❌ | No MCP integration |
 
 ---
 

--- a/Microsoft/azure-apim/README.md
+++ b/Microsoft/azure-apim/README.md
@@ -13,7 +13,6 @@ A policy fragment that can be integrated into an Azure AI Gateway (part of APIM)
 | Streaming | ❌ | Synchronous scanning with 10-second timeout |
 | Pre-tool call | ❌ | Not applicable - designed for direct LLM gateway requests |
 | Post-tool call | ❌ | Not applicable - only scans user input and LLM responses |
-| MCP | ❌ | Not applicable - no MCP support |
 
 ## 🎯 What This Does
 The fragments handle handles scanning of prompts and responses on the following OpenAI API Calls

--- a/Portkey/README.md
+++ b/Portkey/README.md
@@ -13,7 +13,6 @@ This document describes how to integrate Prisma AIRS as a security guardrail wit
 | Streaming | ❌ | Guardrails process complete requests/responses only |
 | Pre-tool call | ❌ | Guardrails intercept at input/output level only |
 | Post-tool call | ❌ | Tool/function result scanning not supported |
-| MCP | ❌ | No MCP scanning |
 
 ---
 

--- a/TrueFoundry/README.md
+++ b/TrueFoundry/README.md
@@ -13,7 +13,6 @@ This document provides instructions for integrating Prisma AIRS with the TrueFou
 | Streaming | ⚠️ | Supported for `v1/messages` API signature only |
 | Pre-tool call | ❌ | Request and response scanning only |
 | Post-tool call | ❌ | Tool result scanning not documented |
-| MCP | ❌ | No MCP integration |
 
 ---
 

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -13,7 +13,6 @@ This document provides instructions for using the Prisma AIRS community node wit
 | Streaming | ❌ | Node processes complete responses after generation |
 | Pre-tool call | ❌ | Workflow-based - not automatic tool interception |
 | Post-tool call | ❌ | Tool result scanning not implemented |
-| MCP | ❌ | MCP tools in workflows are not scanned by this node |
 
 ---
 


### PR DESCRIPTION
Remove MCP scanning phase row from Coverage tables in all integration READMEs and documentation templates as this column is no longer needed.

