### PR TITLE
feat: add Jenkins Declarative Pipeline Model Security integration

### DIFF
--- a/Jenkins/declarative-pipeline/.env.example
+++ b/Jenkins/declarative-pipeline/.env.example
@@ -1,0 +1,19 @@
+# Copy this file to .env and fill in your values.
+# .env is gitignored and will not be committed.
+#
+# These correspond to the Jenkins Credentials needed by the CI/CD pipeline.
+
+# Google Cloud
+GCP_PROJECT_ID=your-project-id
+GCP_REGION=us-central1
+GCP_SA_KEY=                          # Path to or contents of service account JSON key
+
+# Palo Alto Networks Prisma AIRS
+MODEL_SECURITY_CLIENT_ID=your-client-id@your-tsg.iam.panserviceaccount.com
+MODEL_SECURITY_CLIENT_SECRET=your-client-secret
+MODEL_SECURITY_PROFILE_ID=your-security-profile-uuid
+MODEL_SECURITY_API_ENDPOINT=https://api.sase.paloaltonetworks.com/aims
+TSG_ID=your-tsg-id
+
+# HuggingFace
+HF_TOKEN=your-huggingface-token

--- a/Jenkins/declarative-pipeline/.gitignore
+++ b/Jenkins/declarative-pipeline/.gitignore
@@ -1,0 +1,14 @@
+__pycache__/
+*.pyc
+*.pyo
+.env
+*.log
+.terraform/
+terraform.tfstate*
+*.tfvars
+.DS_Store
+venv/
+.venv/
+*.egg-info/
+dist/
+build/

--- a/Jenkins/declarative-pipeline/Jenkinsfile
+++ b/Jenkins/declarative-pipeline/Jenkinsfile
@@ -1,0 +1,211 @@
+// Prisma AIRS Model Security Scan & Deploy Pipeline
+//
+// This pipeline scans an AI model with Palo Alto Networks Prisma AIRS
+// Model Security before deploying it to Google Cloud Vertex AI.
+//
+// Required Jenkins Credentials (configured in Jenkins > Manage Credentials):
+//   - gcp-sa-key              (Secret file)   — GCP service account JSON key
+//   - gcp-project-id          (Secret text)    — GCP project ID
+//   - gcp-region              (Secret text)    — GCP region (e.g. us-central1)
+//   - model-security-client-id     (Secret text) — Prisma AIRS OAuth client ID
+//   - model-security-client-secret (Secret text) — Prisma AIRS OAuth client secret
+//   - model-security-profile-id    (Secret text) — Prisma AIRS security profile UUID
+//   - model-security-api-endpoint  (Secret text) — Prisma AIRS API endpoint URL
+//   - tsg-id                  (Secret text)    — Prisma AIRS Tenant Service Group ID
+//   - hf-token                (Secret text)    — HuggingFace access token
+
+pipeline {
+    agent any
+
+    options {
+        timestamps()
+        timeout(time: 60, unit: 'MINUTES')
+        disableConcurrentBuilds()
+    }
+
+    triggers {
+        // Poll SCM every 5 minutes for changes
+        pollSCM('H/5 * * * *')
+    }
+
+    parameters {
+        booleanParam(
+            name: 'FORCE_RUN',
+            defaultValue: false,
+            description: 'Run the pipeline even if model config has not changed'
+        )
+        booleanParam(
+            name: 'SKIP_DEPLOY',
+            defaultValue: false,
+            description: 'Run security scan only, skip deployment'
+        )
+    }
+
+    environment {
+        CONFIG_FILE = 'config/model-config.yaml'
+    }
+
+    stages {
+
+        // --------------------------------------------------------------------
+        // Customer-specific: Detect whether the model config file changed.
+        // Adapt the changeset condition to match your own config structure.
+        // --------------------------------------------------------------------
+        stage('Detect Changes') {
+            steps {
+                script {
+                    env.MODEL_CHANGED = 'false'
+
+                    if (params.FORCE_RUN) {
+                        echo 'FORCE_RUN enabled — skipping change detection.'
+                        env.MODEL_CHANGED = 'true'
+                        return
+                    }
+
+                    // Check if model config was modified in the latest changeset
+                    def changes = currentBuild.changeSets.collectMany { it.items.collectMany { item -> item.affectedFiles.collect { it.path } } }
+                    if (changes.any { it == 'config/model-config.yaml' }) {
+                        echo 'Model config changed — proceeding with scan.'
+                        env.MODEL_CHANGED = 'true'
+                    } else {
+                        echo 'No model config changes detected. Use FORCE_RUN to override.'
+                    }
+                }
+            }
+        }
+
+        // --------------------------------------------------------------------
+        // AIRS Model Security Integration — Prisma AIRS Model Security Scan
+        //
+        // This stage is the integration point with Palo Alto Networks Prisma
+        // AIRS. It installs the official Model Security SDK from a private
+        // PyPI, then scans the model. The scan returns ALLOWED or BLOCKED.
+        //
+        // To add Prisma AIRS scanning to your own pipeline, replicate this
+        // stage:
+        //   1. Authenticate with SCM to get the private PyPI URL
+        //      (get_pypi_url.sh)
+        //   2. Install the model-security-client SDK
+        //   3. Run the scan script (scan_model.py)
+        //
+        // Required credentials:
+        //   model-security-client-id      — Prisma AIRS OAuth client ID
+        //   model-security-client-secret   — Prisma AIRS OAuth client secret
+        //   model-security-api-endpoint    — Prisma AIRS API endpoint URL
+        //   model-security-profile-id      — Security group UUID for scan rules
+        //   tsg-id                         — Tenant Service Group ID
+        // --------------------------------------------------------------------
+        stage('Prisma AIRS Model Security Scan') {
+            when {
+                expression { env.MODEL_CHANGED == 'true' }
+            }
+            steps {
+                withCredentials([
+                    string(credentialsId: 'model-security-client-id',     variable: 'MODEL_SECURITY_CLIENT_ID'),
+                    string(credentialsId: 'model-security-client-secret', variable: 'MODEL_SECURITY_CLIENT_SECRET'),
+                    string(credentialsId: 'model-security-api-endpoint',  variable: 'MODEL_SECURITY_API_ENDPOINT'),
+                    string(credentialsId: 'model-security-profile-id',    variable: 'MODEL_SECURITY_PROFILE_ID'),
+                    string(credentialsId: 'tsg-id',                       variable: 'TSG_ID'),
+                ]) {
+                    sh '''
+                        echo "=== Setting up Python environment ==="
+                        python3 -m venv .venv
+                        . .venv/bin/activate
+
+                        echo "=== Installing base dependencies ==="
+                        pip install --quiet -r requirements.txt
+
+                        echo "=== Authenticating with Prisma AIRS for SDK access ==="
+                        PYPI_URL=$(bash scripts/get_pypi_url.sh)
+
+                        echo "=== Installing Model Security SDK ==="
+                        pip install --quiet "model-security-client[all]" --extra-index-url "${PYPI_URL}"
+
+                        echo "=== Running Prisma AIRS Model Security Scan ==="
+                        python scripts/scan_model.py --config ${CONFIG_FILE}
+                    '''
+                }
+            }
+        }
+
+        // --------------------------------------------------------------------
+        // Customer-specific: Deploy the scanned model to Google Cloud Vertex
+        // AI. Replace this stage with your own deployment logic (e.g., AWS
+        // SageMaker, Azure ML, on-prem infrastructure, etc.).
+        // Only runs on the main branch after a passing scan.
+        // --------------------------------------------------------------------
+        stage('Deploy Model to Vertex AI') {
+            when {
+                allOf {
+                    expression { env.MODEL_CHANGED == 'true' }
+                    expression { !params.SKIP_DEPLOY }
+                    expression { env.GIT_BRANCH == 'main' || env.GIT_BRANCH == 'origin/main' }
+                }
+            }
+            steps {
+                withCredentials([
+                    file(credentialsId: 'gcp-sa-key',      variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
+                    string(credentialsId: 'gcp-project-id', variable: 'GCP_PROJECT_ID'),
+                    string(credentialsId: 'gcp-region',     variable: 'GCP_REGION'),
+                    string(credentialsId: 'hf-token',       variable: 'HF_TOKEN'),
+                ]) {
+                    sh '''
+                        echo "=== Authenticating with Google Cloud ==="
+                        gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
+                        gcloud config set project "${GCP_PROJECT_ID}"
+
+                        echo "=== Installing dependencies ==="
+                        . .venv/bin/activate
+                        pip install --quiet -r requirements.txt
+
+                        echo "=== Deploying Model ==="
+                        bash scripts/deploy_model.sh
+                    '''
+                }
+            }
+        }
+
+        // --------------------------------------------------------------------
+        // Customer-specific: Validate the deployed endpoint by sending a test
+        // prompt. Replace with your own smoke tests or integration tests.
+        // --------------------------------------------------------------------
+        stage('Test Model Endpoint') {
+            when {
+                allOf {
+                    expression { env.MODEL_CHANGED == 'true' }
+                    expression { !params.SKIP_DEPLOY }
+                    expression { env.GIT_BRANCH == 'main' || env.GIT_BRANCH == 'origin/main' }
+                }
+            }
+            steps {
+                withCredentials([
+                    file(credentialsId: 'gcp-sa-key',      variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
+                    string(credentialsId: 'gcp-project-id', variable: 'GCP_PROJECT_ID'),
+                    string(credentialsId: 'gcp-region',     variable: 'GCP_REGION'),
+                ]) {
+                    sh '''
+                        echo "=== Authenticating with Google Cloud ==="
+                        gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
+
+                        echo "=== Testing Model Endpoint ==="
+                        . .venv/bin/activate
+                        python scripts/test_model.py --config ${CONFIG_FILE}
+                    '''
+                }
+            }
+        }
+    }
+
+    post {
+        success {
+            echo 'Pipeline completed successfully.'
+        }
+        failure {
+            echo 'Pipeline failed. Check the logs above for details.'
+        }
+        always {
+            // Clean up the Python virtual environment
+            sh 'rm -rf .venv || true'
+        }
+    }
+}

--- a/Jenkins/declarative-pipeline/README.md
+++ b/Jenkins/declarative-pipeline/README.md
@@ -1,0 +1,225 @@
+# Jenkins Integration with Prisma AIRS Model Security
+
+This integration adds Palo Alto Networks Prisma AIRS Model Security scanning to a Jenkins Declarative Pipeline. When an AI model changes in the configuration, the pipeline automatically scans the model against security policies before deployment, blocking models that fail the security assessment. This example uses Google Cloud Vertex AI as the deployment target, but the security scanning pattern can be adapted to any infrastructure (e.g., AWS SageMaker, Azure ML, on-prem).
+
+> **Note:** This integration uses **Prisma AIRS Model Security** (pre-deployment model file scanning), which is different from AI Runtime Security (prompt/response scanning). It uses the [Model Security SDK](https://docs.paloaltonetworks.com/ai-runtime-security/ai-model-security) rather than the AIRS Runtime API.
+
+---
+
+## Coverage
+
+> For detection categories and use cases, see the [Prisma AIRS documentation](https://pan.dev/prisma-airs/api/airuntimesecurity/usecases/).
+
+This integration scans **AI model files** before deployment. It does not scan prompts or responses at inference time — that is handled by the AI Runtime Security integrations elsewhere in this repository.
+
+| Scanning Phase | Supported | Description |
+|----------------|:---------:|-------------|
+| Model file scan | ✅ | Scans model weights/binaries for security risks before deployment |
+| Prompt | N/A | Use an AI Runtime Security integration for prompt scanning |
+| Response | N/A | Use an AI Runtime Security integration for response scanning |
+| Streaming | N/A | Not applicable to model file scanning |
+| Pre-tool call | N/A | Not applicable to model file scanning |
+| Post-tool call | N/A | Not applicable to model file scanning |
+
+### What Gets Scanned
+
+Prisma AIRS Model Security evaluates AI models for:
+
+- **Model provenance and supply chain risks** — Verifying the model source and integrity
+- **Known vulnerabilities** — Checking against known CVEs and security advisories
+- **Malicious payloads** — Detecting embedded malicious code or backdoors
+- **Compliance violations** — Ensuring models meet organizational security policies
+- **Training data risks** — Identifying potential data poisoning indicators
+
+---
+
+## Prerequisites
+
+* A Jenkins instance (2.400+) with the [Pipeline plugin](https://plugins.jenkins.io/workflow-aggregator/) installed
+* Python 3.11+ available on the Jenkins agent
+* `gcloud` CLI, `jq`, and `curl` installed on the Jenkins agent
+* A Palo Alto Networks Prisma AIRS subscription with Model Security enabled
+* Access to Strata Cloud Manager for credentials and security profile configuration
+* (For the included example deployment) A Google Cloud project with the [Vertex AI API](https://console.cloud.google.com/apis/library/aiplatform.googleapis.com) enabled
+
+---
+
+## Configuration Steps
+
+### Step 1: Obtain Prisma AIRS Model Security Credentials
+
+1. Log in to the **Strata Cloud Manager**
+2. Create a **Service Account** under Settings > Access Control
+3. Note the **Client ID**, **Client Secret**, and **TSG ID**
+4. Configure a **Security Profile** (Model Security) and note the profile UUID
+5. Note your **API Endpoint** URL (e.g., `https://api.sase.paloaltonetworks.com/aims`)
+
+### Step 2: Configure Jenkins Credentials
+
+Add the following credentials in Jenkins under **Manage Jenkins > Manage Credentials** in the appropriate scope:
+
+| Credential ID | Type | Description |
+|---------------|------|-------------|
+| `model-security-client-id` | Secret text | Prisma AIRS OAuth client ID (service account) |
+| `model-security-client-secret` | Secret text | Prisma AIRS OAuth client secret |
+| `model-security-profile-id` | Secret text | Security profile UUID |
+| `model-security-api-endpoint` | Secret text | API endpoint URL |
+| `tsg-id` | Secret text | Tenant Service Group ID |
+
+For the included Vertex AI deployment example, also configure:
+
+| Credential ID | Type | Description |
+|---------------|------|-------------|
+| `gcp-project-id` | Secret text | Google Cloud project ID |
+| `gcp-region` | Secret text | GCP region (e.g., `us-central1`) |
+| `gcp-sa-key` | Secret file | GCP service account JSON key (with Vertex AI Admin role) |
+| `hf-token` | Secret text | HuggingFace access token (for gated models) |
+
+> **Note:** These credentials differ from the standard `PRISMA_AIRS_API_KEY` / `PRISMA_AIRS_PROFILE_NAME` / `PRISMA_AIRS_URL` used by AI Runtime Security integrations. Model Security uses OAuth2 client credentials via the `model-security-client` SDK.
+
+### Step 3: Add the Security Scan Stage to Your Pipeline
+
+The core integration is the **Prisma AIRS Model Security Scan** stage in the `Jenkinsfile`. It:
+
+1. Authenticates with Prisma AIRS to get a private PyPI URL (`scripts/get_pypi_url.sh`)
+2. Installs the `model-security-client` SDK from the private PyPI
+3. Runs `scripts/scan_model.py` which scans the model and exits non-zero if BLOCKED
+
+To add this to your own pipeline, copy the scan stage and the supporting files (`scripts/scan_model.py`, `scripts/get_pypi_url.sh`), then configure the required credentials.
+
+### Step 4: Configure the Model
+
+Edit `config/model-config.yaml` to specify the model to scan:
+
+```yaml
+model:
+  huggingface_id: "google/gemma-3-1b-it"
+  display_name: "gemma-3-1b-it"
+  version: "1.0"
+
+security:
+  scan_enabled: true
+```
+
+---
+
+## Architecture
+
+```
+Developer changes config/model-config.yaml
+                    |
+                    v
+        Jenkins Pipeline Triggered
+        (SCM polling or manual build)
+                    |
+                    v
+       +----------------------------+
+       | Prisma AIRS Model Security |
+       |           Scan             |
+       +----------------------------+
+                    |
+              +-----+-----+
+              |           |
+           ALLOWED     BLOCKED
+              |           |
+              v           v
+      Deploy model    Pipeline fails.
+      to target       Model is NOT
+      infrastructure  deployed.
+```
+
+**On Non-Main Branches:** The security scan runs and reports pass/fail status, but the model is not deployed. This allows developers to verify model compliance before merging.
+
+**On Main Branch:** If the security scan passes, the model is automatically deployed and validated.
+
+---
+
+## Validation
+
+### Trigger a Scan
+
+Commit a change to `config/model-config.yaml` and push to the repository. The Jenkins pipeline will detect the change via SCM polling and run the security scan automatically. You can also use **Build with Parameters** and check **FORCE_RUN** to trigger manually.
+
+### Verify in Build Logs
+
+The scan output in the Jenkins build console will show:
+
+- The model being scanned and its URI
+- The scan UUID for tracking
+- The outcome: `ALLOWED` or `BLOCKED`
+- Any rule violations with severity and description
+
+### Verify in Strata Cloud Manager
+
+All scan results are visible in the Strata Cloud Manager dashboard under Model Security activity logs.
+
+### Example Output
+
+```
+================================================================
+  PRISMA AIRS MODEL SECURITY SCAN RESULTS
+================================================================
+  Model:        google/gemma-3-1b-it
+  Scan UUID:    a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  Outcome:      EvalOutcome.ALLOWED
+  Summary:      Model passed all security checks
+  ...
+================================================================
+
+ALLOWED: Model approved by Prisma AIRS security policy.
+The model is cleared for deployment.
+```
+
+---
+
+## Technical Requirements
+
+1. This integration uses the **Model Security SDK** (`model-security-client`), not the AIRS Runtime API. Authentication is via OAuth2 client credentials (not API key).
+
+2. The SDK is installed from a **private PyPI** repository. The `scripts/get_pypi_url.sh` script handles authentication and URL retrieval.
+
+3. The scan script (`scripts/scan_model.py`) sets labels including `pipeline: jenkins` for tracking scan origin in Strata Cloud Manager.
+
+---
+
+## Repository Structure
+
+```
+.
+├── Jenkinsfile                          # Jenkins Declarative Pipeline definition
+├── config/
+│   └── model-config.yaml               # Model configuration (trigger file)
+├── scripts/
+│   ├── scan_model.py                   # Prisma AIRS Model Security scan
+│   ├── get_pypi_url.sh                 # Private PyPI authentication
+│   ├── deploy_model.sh                 # Example: Vertex AI deployment
+│   ├── test_model.py                   # Example: Endpoint validation
+│   └── undeploy_model.sh              # Example: Cost cleanup
+├── .env.example                        # Environment variable reference
+├── requirements.txt                    # Python dependencies
+└── README.md
+```
+
+> **Note:** `deploy_model.sh`, `test_model.py`, and `undeploy_model.sh` are example scripts for Google Cloud Vertex AI deployment. Replace these with your own deployment target (e.g., AWS SageMaker, Azure ML, on-prem).
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| `get_pypi_url.sh` fails with auth error | Verify `model-security-client-id`, `model-security-client-secret`, and `tsg-id` credentials are correct |
+| Scan returns unexpected outcome | Check that `model-security-profile-id` points to a valid, active security profile |
+| SDK install fails | Ensure the private PyPI URL was retrieved successfully in the previous step |
+| Credentials not found | Verify credentials are in the correct Jenkins scope (global or folder-level) for the pipeline job |
+| SCM polling not triggering | Check the poll schedule in the Jenkinsfile (`H/5 * * * *`) and verify the repository URL is accessible |
+
+---
+
+## Links
+
+- [Source repository](https://github.com/bartpmika/model-security-scan-via-jenkins-actions)
+- [Prisma AIRS Model Security documentation](https://docs.paloaltonetworks.com/ai-runtime-security/ai-model-security)
+- [Model Security SDK installation guide](https://docs.paloaltonetworks.com/ai-runtime-security/ai-model-security/model-security-to-secure-your-ai-models/get-started-with-ai-model-security/install-ai-model-security)
+- [Prisma AIRS API documentation](https://pan.dev/airs/)
+- [Jenkins Pipeline documentation](https://www.jenkins.io/doc/book/pipeline/)

--- a/Jenkins/declarative-pipeline/config/model-config.yaml
+++ b/Jenkins/declarative-pipeline/config/model-config.yaml
@@ -1,0 +1,20 @@
+# Model Configuration
+# Changing this file triggers the Prisma AIRS Model Security Scan pipeline.
+# The pipeline will scan the specified model and only deploy it if the
+# security scan passes.
+
+model:
+  huggingface_id: "google/gemma-3-1b-it"
+  display_name: "gemma-3-1b-it"
+  description: "Google Gemma 3 1B Instruction-Tuned model deployed via Vertex AI Model Garden"
+  version: "1.0"
+
+deployment:
+  machine_type: "g2-standard-12"
+  accelerator_type: "NVIDIA_L4"
+  accelerator_count: 1
+  region: "us-central1"
+
+security:
+  scan_enabled: true
+  security_profile_id: ""  # Set via MODEL_SECURITY_PROFILE_ID env var or Jenkins credential

--- a/Jenkins/declarative-pipeline/requirements.txt
+++ b/Jenkins/declarative-pipeline/requirements.txt
@@ -1,0 +1,2 @@
+pyyaml>=6.0
+python-dotenv>=1.0

--- a/Jenkins/declarative-pipeline/scripts/deploy_model.sh
+++ b/Jenkins/declarative-pipeline/scripts/deploy_model.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Deploy a model from Vertex AI Model Garden to a Vertex AI endpoint.
+# Reads configuration from config/model-config.yaml.
+set -euo pipefail
+
+CONFIG_FILE="${CONFIG_FILE:-config/model-config.yaml}"
+
+# Parse configuration values from YAML
+MODEL_ID=$(python3 -c "import yaml; c=yaml.safe_load(open('${CONFIG_FILE}')); print(c['model']['huggingface_id'])")
+DISPLAY_NAME=$(python3 -c "import yaml; c=yaml.safe_load(open('${CONFIG_FILE}')); print(c['model']['display_name'])")
+MACHINE_TYPE=$(python3 -c "import yaml; c=yaml.safe_load(open('${CONFIG_FILE}')); print(c['deployment']['machine_type'])")
+ACCEL_TYPE=$(python3 -c "import yaml; c=yaml.safe_load(open('${CONFIG_FILE}')); print(c['deployment']['accelerator_type'])")
+ACCEL_COUNT=$(python3 -c "import yaml; c=yaml.safe_load(open('${CONFIG_FILE}')); print(c['deployment']['accelerator_count'])")
+REGION="${GCP_REGION:-us-central1}"
+PROJECT="${GCP_PROJECT_ID:?ERROR: GCP_PROJECT_ID environment variable is required}"
+
+ENDPOINT_DISPLAY_NAME="${DISPLAY_NAME}-secure"
+
+echo "============================================================"
+echo "  Deploying Model to Vertex AI"
+echo "============================================================"
+echo "  Model:         ${MODEL_ID}"
+echo "  Display Name:  ${ENDPOINT_DISPLAY_NAME}"
+echo "  Machine Type:  ${MACHINE_TYPE}"
+echo "  Accelerator:   ${ACCEL_TYPE} x ${ACCEL_COUNT}"
+echo "  Region:        ${REGION}"
+echo "  Project:       ${PROJECT}"
+echo "============================================================"
+
+gcloud config set project "${PROJECT}"
+
+# Clean up any existing endpoint with the same display name to avoid duplicates
+EXISTING_ENDPOINT=$(gcloud ai endpoints list \
+  --region="${REGION}" \
+  --filter="displayName=${ENDPOINT_DISPLAY_NAME}" \
+  --format="value(name)" | head -1 | awk -F/ '{print $NF}')
+
+if [ -n "${EXISTING_ENDPOINT}" ]; then
+  echo "Found existing endpoint: ${EXISTING_ENDPOINT}"
+  echo "Cleaning up before redeploying..."
+  DEPLOYED_MODEL_IDS=$(gcloud ai endpoints describe "${EXISTING_ENDPOINT}" \
+    --region="${REGION}" \
+    --format="value(deployedModels.id)" 2>/dev/null || true)
+  for dm_id in ${DEPLOYED_MODEL_IDS}; do
+    echo "  Undeploying model: ${dm_id}"
+    gcloud ai endpoints undeploy-model "${EXISTING_ENDPOINT}" \
+      --region="${REGION}" \
+      --deployed-model-id="${dm_id}" \
+      --quiet
+  done
+  echo "  Deleting endpoint: ${EXISTING_ENDPOINT}"
+  gcloud ai endpoints delete "${EXISTING_ENDPOINT}" \
+    --region="${REGION}" \
+    --quiet
+  echo "Cleanup complete."
+  echo ""
+fi
+
+gcloud ai model-garden models deploy \
+  --model="${MODEL_ID}" \
+  --machine-type="${MACHINE_TYPE}" \
+  --accelerator-type="${ACCEL_TYPE}" \
+  --accelerator-count="${ACCEL_COUNT}" \
+  --region="${REGION}" \
+  --endpoint-display-name="${ENDPOINT_DISPLAY_NAME}" \
+  --hugging-face-access-token="${HF_TOKEN:-}" \
+  --accept-eula
+
+echo ""
+echo "Model deployed successfully."
+echo "Endpoint display name: ${ENDPOINT_DISPLAY_NAME}"
+echo ""
+echo "To test the endpoint, run:"
+echo "  python scripts/test_model.py --config ${CONFIG_FILE}"

--- a/Jenkins/declarative-pipeline/scripts/get_pypi_url.sh
+++ b/Jenkins/declarative-pipeline/scripts/get_pypi_url.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Model Security Private PyPI Authentication Script
+# Authenticates with SCM and retrieves PyPI repository URL
+#
+
+set -euo pipefail
+
+# Check required environment variables
+: "${MODEL_SECURITY_CLIENT_ID:?Error: MODEL_SECURITY_CLIENT_ID not set}"
+: "${MODEL_SECURITY_CLIENT_SECRET:?Error: MODEL_SECURITY_CLIENT_SECRET not set}"
+: "${TSG_ID:?Error: TSG_ID not set}"
+
+# Set default endpoints
+API_ENDPOINT="${MODEL_SECURITY_API_ENDPOINT:-https://api.sase.paloaltonetworks.com/aims}"
+TOKEN_ENDPOINT="${MODEL_SECURITY_TOKEN_ENDPOINT:-https://auth.apps.paloaltonetworks.com/oauth2/access_token}"
+
+# Get SCM access token
+TOKEN_RESPONSE=$(curl -sf -X POST "$TOKEN_ENDPOINT" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -u "$MODEL_SECURITY_CLIENT_ID:$MODEL_SECURITY_CLIENT_SECRET" \
+    -d "grant_type=client_credentials&scope=tsg_id:$TSG_ID") || {
+    echo "Error: Failed to obtain SCM access token" >&2
+    exit 1
+}
+
+SCM_TOKEN=$(echo "$TOKEN_RESPONSE" | jq -r '.access_token')
+if [[ -z "$SCM_TOKEN" || "$SCM_TOKEN" == "null" ]]; then
+    echo "Error: Failed to extract access token from response" >&2
+    exit 1
+fi
+
+# Get PyPI URL
+PYPI_RESPONSE=$(curl -sf -X GET "$API_ENDPOINT/mgmt/v1/pypi/authenticate" \
+    -H "Authorization: Bearer $SCM_TOKEN") || {
+    echo "Error: Failed to retrieve PyPI URL" >&2
+    exit 1
+}
+
+PYPI_URL=$(echo "$PYPI_RESPONSE" | jq -r '.url')
+if [[ -z "$PYPI_URL" || "$PYPI_URL" == "null" ]]; then
+    echo "Error: Failed to extract PyPI URL from response" >&2
+    exit 1
+fi
+
+echo "$PYPI_URL"

--- a/Jenkins/declarative-pipeline/scripts/scan_model.py
+++ b/Jenkins/declarative-pipeline/scripts/scan_model.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Prisma AIRS Model Security Scanner
+
+Scans an AI model against Palo Alto Prisma AIRS security policies
+using the official Model Security SDK. Exits non-zero if the model
+fails the security assessment, blocking the CI/CD pipeline.
+"""
+
+import argparse
+import os
+import sys
+
+import yaml
+from dotenv import load_dotenv
+from model_security_client.api import ModelSecurityAPIClient
+
+load_dotenv()
+
+
+def print_scan_results(result, model_name):
+    """Pretty-print the scan results for CI log visibility."""
+    print()
+    print("=" * 64)
+    print("  PRISMA AIRS MODEL SECURITY SCAN RESULTS")
+    print("=" * 64)
+    print(f"  Model:        {model_name}")
+    print(f"  Scan UUID:    {getattr(result, 'uuid', 'N/A')}")
+    print(f"  Outcome:      {result.eval_outcome}")
+    print(f"  Summary:      {getattr(result, 'eval_summary', 'N/A')}")
+    print(f"  Sec. Group:   {getattr(result, 'security_group_name', 'N/A')}")
+    print(f"  Rules:        {getattr(result, 'enabled_rule_count_snapshot', 'N/A')}")
+    print(f"  Files Scanned:{getattr(result, 'total_files_scanned', 'N/A')}")
+    print(f"  Files Skipped:{getattr(result, 'total_files_skipped', 'N/A')}")
+
+    violations = getattr(result, 'rule_violations', None) or getattr(result, 'findings', [])
+    if violations:
+        print(f"  Violations:   {len(violations)}")
+        for v in violations:
+            severity = getattr(v, 'severity', getattr(v, 'level', 'unknown'))
+            desc = getattr(v, 'description', getattr(v, 'rule_name', 'No description'))
+            print(f"    [{str(severity).upper()}] {desc}")
+
+    print("=" * 64)
+    print()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Scan an AI model with Prisma AIRS Model Security"
+    )
+    parser.add_argument(
+        "--config",
+        required=True,
+        help="Path to the model configuration YAML file",
+    )
+    args = parser.parse_args()
+
+    with open(args.config) as f:
+        config = yaml.safe_load(f)
+
+    if not config.get("security", {}).get("scan_enabled", True):
+        print("Security scan is disabled in model config. Skipping.")
+        sys.exit(0)
+
+    # Allow overriding security_profile_id from environment variable
+    profile_id = os.environ.get("MODEL_SECURITY_PROFILE_ID")
+    if profile_id:
+        config.setdefault("security", {})["security_profile_id"] = profile_id
+
+    security_group_uuid = config["security"]["security_profile_id"]
+    if not security_group_uuid:
+        print("ERROR: No security_profile_id configured.")
+        print("Set MODEL_SECURITY_PROFILE_ID env var or configure it in model-config.yaml.")
+        sys.exit(1)
+
+    model_name = config["model"]["huggingface_id"]
+    model_uri = f"https://huggingface.co/{model_name}"
+    api_endpoint = os.environ.get(
+        "MODEL_SECURITY_API_ENDPOINT",
+        "https://api.sase.paloaltonetworks.com/aims",
+    )
+
+    print(f"Initializing Prisma AIRS Model Security SDK...")
+    client = ModelSecurityAPIClient(base_url=api_endpoint)
+
+    labels = {
+        "deployment_target": "vertex_ai",
+        "machine_type": config["deployment"]["machine_type"],
+        "version": config["model"].get("version", "unknown").replace(".", "-"),
+        "pipeline": "jenkins",
+    }
+
+    print(f"Scanning model: {model_name}")
+    print(f"  URI: {model_uri}")
+    print(f"  Security Group: {security_group_uuid}")
+    print(f"  Labels: {labels}")
+
+    result = client.scan(
+        security_group_uuid=security_group_uuid,
+        model_uri=model_uri,
+        labels=labels,
+    )
+
+    print_scan_results(result, model_name)
+
+    outcome = str(result.eval_outcome)
+    if "BLOCKED" in outcome:
+        print("BLOCKED: Model blocked by Prisma AIRS security policy.")
+        print("The model will NOT be deployed.")
+        sys.exit(1)
+    elif "ALLOWED" in outcome:
+        print("ALLOWED: Model approved by Prisma AIRS security policy.")
+        print("The model is cleared for deployment.")
+    else:
+        print(f"WARNING: Unexpected scan outcome '{outcome}'. Blocking deployment.")
+        print("The model will NOT be deployed.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/Jenkins/declarative-pipeline/scripts/test_model.py
+++ b/Jenkins/declarative-pipeline/scripts/test_model.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Test a deployed Vertex AI model endpoint.
+
+Discovers the endpoint by display name, sends a test prompt via
+the dedicated endpoint DNS, and prints the model response.
+Can be used in CI/CD or locally.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+import yaml
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def get_endpoint_info(project_id, region, display_name):
+    """Find the endpoint ID and dedicated DNS for a deployed model."""
+    result = subprocess.run(
+        [
+            "gcloud", "ai", "endpoints", "list",
+            "--project", project_id,
+            "--region", region,
+            "--format", "json",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    endpoints = json.loads(result.stdout)
+    for ep in endpoints:
+        if display_name in ep.get("displayName", ""):
+            endpoint_id = ep["name"].split("/")[-1]
+            dedicated_dns = ep.get("dedicatedEndpointDns", "")
+            return endpoint_id, dedicated_dns
+    return None, None
+
+
+def send_prediction(project_id, region, endpoint_id, dedicated_dns, prompt):
+    """Send a prediction request to the Vertex AI endpoint."""
+    access_token = subprocess.run(
+        ["gcloud", "auth", "print-access-token"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+    # Use dedicated endpoint DNS with rawPredict
+    url = (
+        f"https://{dedicated_dns}/v1/projects/{project_id}"
+        f"/locations/{region}/endpoints/{endpoint_id}:rawPredict"
+    )
+
+    import urllib.request
+    import urllib.error
+
+    request_payload = json.dumps({
+        "prompt": prompt,
+        "max_tokens": 256,
+        "temperature": 0.7,
+    }).encode()
+
+    req = urllib.request.Request(
+        url,
+        data=request_payload,
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode()
+        print(f"ERROR: {e.code} {e.reason}")
+        print(f"Response: {error_body}")
+        raise
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Test a deployed Vertex AI model endpoint"
+    )
+    parser.add_argument(
+        "--config",
+        required=True,
+        help="Path to the model configuration YAML file",
+    )
+    parser.add_argument(
+        "--prompt",
+        default="Explain what AI model security scanning is in one sentence.",
+        help="Test prompt to send to the model",
+    )
+    args = parser.parse_args()
+
+    with open(args.config) as f:
+        config = yaml.safe_load(f)
+
+    project_id = os.environ.get("GCP_PROJECT_ID")
+    region = os.environ.get("GCP_REGION", config["deployment"].get("region", "us-central1"))
+
+    if not project_id:
+        print("ERROR: GCP_PROJECT_ID environment variable is required.")
+        sys.exit(1)
+
+    display_name = config["model"]["display_name"] + "-secure"
+
+    print(f"Looking for endpoint: {display_name}")
+    print(f"  Project: {project_id}")
+    print(f"  Region:  {region}")
+    print()
+
+    endpoint_id, dedicated_dns = get_endpoint_info(project_id, region, display_name)
+
+    if not endpoint_id:
+        print(f"ERROR: No endpoint found matching '{display_name}'")
+        print("Make sure the model has been deployed first.")
+        sys.exit(1)
+
+    print(f"Found endpoint: {endpoint_id}")
+    print(f"Dedicated DNS: {dedicated_dns}")
+    print(f"Sending test prompt: \"{args.prompt}\"")
+    print()
+
+    max_retries = 20
+    retry_delay = 90
+    for attempt in range(1, max_retries + 1):
+        try:
+            response = send_prediction(project_id, region, endpoint_id, dedicated_dns, args.prompt)
+            break
+        except Exception as e:
+            if attempt == max_retries:
+                print(f"ERROR: Endpoint not ready after {max_retries} attempts. Giving up.")
+                sys.exit(1)
+            print(f"Attempt {attempt}/{max_retries} failed ({e}). Retrying in {retry_delay}s...")
+            time.sleep(retry_delay)
+
+    print("=" * 64)
+    print("  MODEL RESPONSE")
+    print("=" * 64)
+    predictions = response.get("predictions", [])
+    if predictions:
+        for p in predictions:
+            print(p)
+    else:
+        print(json.dumps(response, indent=2))
+    print("=" * 64)
+    print()
+    print("Endpoint test PASSED - model is responding.")
+
+
+if __name__ == "__main__":
+    main()

--- a/Jenkins/declarative-pipeline/scripts/undeploy_model.sh
+++ b/Jenkins/declarative-pipeline/scripts/undeploy_model.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Undeploy and clean up a Vertex AI model endpoint to stop incurring GPU costs.
+# Usage: GCP_PROJECT_ID=your-project GCP_REGION=us-central1 ./scripts/undeploy_model.sh
+set -euo pipefail
+
+CONFIG_FILE="${CONFIG_FILE:-config/model-config.yaml}"
+
+DISPLAY_NAME=$(python3 -c "import yaml; c=yaml.safe_load(open('${CONFIG_FILE}')); print(c['model']['display_name'])")
+ENDPOINT_DISPLAY_NAME="${DISPLAY_NAME}-secure"
+REGION="${GCP_REGION:-us-central1}"
+PROJECT="${GCP_PROJECT_ID:?ERROR: Set GCP_PROJECT_ID environment variable}"
+
+echo "Looking for endpoint: ${ENDPOINT_DISPLAY_NAME}"
+echo "  Project: ${PROJECT}"
+echo "  Region:  ${REGION}"
+
+ENDPOINT_IDS=$(gcloud ai endpoints list \
+  --project="${PROJECT}" \
+  --region="${REGION}" \
+  --filter="displayName~${ENDPOINT_DISPLAY_NAME}" \
+  --format="value(name)" | awk -F/ '{print $NF}')
+
+if [ -z "${ENDPOINT_IDS}" ]; then
+  echo "No matching endpoints found. Nothing to clean up."
+  exit 0
+fi
+
+for ENDPOINT_ID in ${ENDPOINT_IDS}; do
+  echo "Found endpoint: ${ENDPOINT_ID}"
+  echo "Undeploying all models from the endpoint..."
+
+  DEPLOYED_MODEL_IDS=$(gcloud ai endpoints describe "${ENDPOINT_ID}" \
+    --project="${PROJECT}" \
+    --region="${REGION}" \
+    --format="value(deployedModels.id)" 2>/dev/null || true)
+
+  for dm_id in ${DEPLOYED_MODEL_IDS}; do
+    echo "  Undeploying model: ${dm_id}"
+    gcloud ai endpoints undeploy-model "${ENDPOINT_ID}" \
+      --project="${PROJECT}" \
+      --region="${REGION}" \
+      --deployed-model-id="${dm_id}" \
+      --quiet
+  done
+
+  echo "Deleting endpoint: ${ENDPOINT_ID}"
+  gcloud ai endpoints delete "${ENDPOINT_ID}" \
+    --project="${PROJECT}" \
+    --region="${REGION}" \
+    --quiet
+
+  echo "Endpoint ${ENDPOINT_ID} deleted."
+done
+
+echo "All matching endpoints cleaned up. GPU costs stopped."

--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ This repository contains setup guides for embedding Prisma AIRS security into AI
 | [n8n](./n8n/) | Workflow Automation | ✅ | ✅ | ❌ | ❌ | ❌ |
 | [Portkey](./Portkey/) | AI Gateway | ✅ | ✅ | ❌ | ❌ | ❌ |
 | [TrueFoundry](./TrueFoundry/) | AI Gateway | ✅ | ✅ | ⚠️ | ❌ | ❌ |
+| [Jenkins (Pipeline)](./Jenkins/declarative-pipeline/) | CI/CD Pipeline | N/A | N/A | N/A | N/A | N/A |
 
 **Legend:** ✅ Full support | ⚠️ Partial support | ❌ Not supported
+
+**N/A** — [Jenkins](./Jenkins/declarative-pipeline/) uses Prisma AIRS **Model Security** (pre-deployment model file scanning), not AI Runtime Security. See the [integration README](./Jenkins/declarative-pipeline/) for model scanning coverage.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a Jenkins Declarative Pipeline integration for Prisma AIRS **Model Security** scanning in CI/CD pipelines
- Scans AI model files (weights/binaries) **before deployment** using the `model-security-client` SDK
- Blocks deployment if the model fails the security assessment
- Includes a complete working example with Google Cloud Vertex AI deployment
- Source: https://github.com/bartpmika/model-security-scan-via-jenkins-actions

**Note:** This is a **Model Security** integration (pre-deployment model file scanning), complementing the GitHub Actions integration in #24. The integration matrix uses N/A for the runtime scanning columns since they don't apply to model file scanning.

## Files Added

- `Jenkins/declarative-pipeline/README.md` — Integration guide following the CONTRIBUTING.md template
- `Jenkins/declarative-pipeline/Jenkinsfile` — Jenkins Declarative Pipeline (4 stages: detect changes, scan, deploy, test)
- `Jenkins/declarative-pipeline/scripts/scan_model.py` — Core AIRS Model Security scan script
- `Jenkins/declarative-pipeline/scripts/get_pypi_url.sh` — Private PyPI authentication
- `Jenkins/declarative-pipeline/scripts/deploy_model.sh` — Example Vertex AI deployment
- `Jenkins/declarative-pipeline/scripts/test_model.py` — Example endpoint validation
- `Jenkins/declarative-pipeline/scripts/undeploy_model.sh` — Example cost cleanup
- `Jenkins/declarative-pipeline/config/model-config.yaml` — Model configuration
- `Jenkins/declarative-pipeline/.env.example`, `.gitignore`, `requirements.txt` — Supporting files
- Updated root `README.md` integration matrix with new row and footnote

## Test plan

- [ ] Verify all file paths and links in the integration README render correctly on GitHub
- [ ] Confirm the integration matrix row and N/A footnote display properly in root README
- [ ] Verify the source repo pipeline is passing: https://github.com/bartpmika/model-security-scan-via-jenkins-actions
- [ ] Review that scripts match the source repo (only difference from GitHub Actions version: `pipeline: "jenkins"` label in `scan_model.py`)