### PR TITLE
docs: add Jenkins integration to README support matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ This repository contains setup guides for embedding Prisma AIRS security into AI
 | [Portkey](./Portkey/) | AI Gateway | ✅ | ✅ | ❌ | ❌ | ❌ |
 | [TrueFoundry](./TrueFoundry/) | AI Gateway | ✅ | ✅ | ⚠️ | ❌ | ❌ |
 | [GitHub (Actions)](./GitHub/github-actions/) | CI/CD Pipeline | N/A | N/A | N/A | N/A | N/A |
+| [Jenkins (Pipeline)](./Jenkins/declarative-pipeline/) | CI/CD Pipeline | N/A | N/A | N/A | N/A | N/A |
 
 **Legend:** ✅ Full support | ⚠️ Partial support | ❌ Not supported
 
-**N/A** — [GitHub Actions](./GitHub/github-actions/) uses Prisma AIRS **Model Security** (pre-deployment model file scanning), not AI Runtime Security. See the [integration README](./GitHub/github-actions/) for model scanning coverage.
+**N/A** — [GitHub Actions](./GitHub/github-actions/) and [Jenkins](./Jenkins/declarative-pipeline/) use Prisma AIRS **Model Security** (pre-deployment model file scanning), not AI Runtime Security. See each integration's README for model scanning coverage.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ This repository contains setup guides for embedding Prisma AIRS security into AI
 
 **Legend:** ✅ Full support | ⚠️ Partial support | ❌ Not supported
 
-**N/A** — [GitHub Actions](./GitHub/github-actions/) and [Jenkins](./Jenkins/declarative-pipeline/) use Prisma AIRS **Model Security** (pre-deployment model file scanning), not AI Runtime Security. See each integration's README for model scanning coverage.
+**N/A** — [GitHub Actions](./GitHub/github-actions/) uses Prisma AIRS **Model Security** (pre-deployment model file scanning), not AI Runtime Security. See the [integration README](./GitHub/github-actions/) for model scanning coverage.
+
+**N/A** — [Jenkins](./Jenkins/declarative-pipeline/) uses Prisma AIRS **Model Security** (pre-deployment model file scanning), not AI Runtime Security. See the [integration README](./Jenkins/declarative-pipeline/) for model scanning coverage.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds the Jenkins (Pipeline) row to the Integration Support Matrix in the root README
- Updates the N/A footnote to reference both GitHub Actions and Jenkins

These changes were part of PR #26 but were dropped during the merge.

## Test plan

- [ ] Verify the Jenkins row renders correctly in the integration matrix table
- [ ] Verify the N/A footnote links to the correct Jenkins README path