### PR TITLE
docs: clarify that profile_name should be set explicitly

### DIFF
--- a/LiteLLM/README.md
+++ b/LiteLLM/README.md
@@ -75,7 +75,7 @@ guardrails:
     * `pre_mcp_call`: Scans MCP tool input *before* tool execution.
     * `during_mcp_call`: Scans MCP tool input *in parallel* with tool execution.
 * **`api_key`**: Your Prisma AIRS API key. It's best practice to load this from an environment variable.
-* **`profile_name`**: The name of your Security Profile from Strata Cloud Manager. Optional if your API key has a linked profile.
+* **`profile_name`**: The name of your Security Profile from Strata Cloud Manager. Technically optional if your AIRS API key has a linked default profile, but most keys do not. Set this field explicitly to avoid an HTTP 400 `"No default AI profile available"` from AIRS, which LiteLLM wraps as a 500 `"Security scan failed"`.
 * **`api_base`**: Regional API endpoint. Use the endpoint matching your deployment profile region for lower latency and data residency compliance.
 
 ### Step 3: Set Environment Variables and Start the Gateway

--- a/LiteLLM/examples/config-aws.yaml
+++ b/LiteLLM/examples/config-aws.yaml
@@ -1,4 +1,7 @@
 # litellm config.yaml for AWS Bedrock
+# This file shows model wiring only. To enable Prisma AIRS guardrails,
+# copy the guardrails: block from config-all.yaml. Set profile_name
+# explicitly in that block. See README "Configure the Guardrail".
 
 model_list:
   - model_name: claude-3-haiku # A friendly alias you'll use in your API calls

--- a/LiteLLM/examples/config-azure.yaml
+++ b/LiteLLM/examples/config-azure.yaml
@@ -1,3 +1,8 @@
+# litellm config.yaml for Azure OpenAI
+# This file shows model wiring only. To enable Prisma AIRS guardrails,
+# copy the guardrails: block from config-all.yaml. Set profile_name
+# explicitly in that block. See README "Configure the Guardrail".
+
 model_list:
   - model_name: gpt-4o
     litellm_params:


### PR DESCRIPTION
The README currently says `profile_name` is "Optional if your API key has a linked profile." That is technically true, but most production AIRS API keys do not have a linked default profile. Customers who follow the docs literally and omit `profile_name` see scans fail with:

```
HTTP 400 from AIRS: "No default AI profile available"
wrapped by LiteLLM as: HTTP 500 "Security scan failed - request blocked for safety"
```

The 500 looks like the guardrail is doing its job. It is not. The scan never ran.

## Changes

1. **`LiteLLM/README.md`**: reframe `profile_name` as "set this explicitly" with a note about the failure mode, instead of "optional if...".

2. **`LiteLLM/examples/config-aws.yaml` and `config-azure.yaml`**: add a header comment pointing readers to `config-all.yaml` for the guardrails block, since these files only show model wiring.

Reproduced locally against a working AIRS tenant: a key with no linked default profile + a config without `profile_name` produces the wrapped 500. Adding `profile_name` resolves it cleanly and the AIRS response then includes a `profile_id`, which is the diagnostic signal that the field made it into the scan request.

A follow-up PR will align variable names in `env.example` (currently `MY_AIRS_API_KEY`, README expects `PANW_PRISMA_AIRS_API_KEY`) and add `PANW_PRISMA_AIRS_PROFILE_NAME` there. Splitting that out since it is a behavior-affecting rename, not just docs.