### PR TITLE
docs: align env.example variable names with README config

### DIFF
--- a/LiteLLM/examples/env.example
+++ b/LiteLLM/examples/env.example
@@ -1,6 +1,7 @@
 # This file contains secret keys. Add it to your .gitignore!
  #AIRS
- MY_AIRS_API_KEY=<AIRS API KEY>
+ PANW_PRISMA_AIRS_API_KEY=<AIRS API KEY>
+ PANW_PRISMA_AIRS_PROFILE_NAME=<security profile name from Strata Cloud Manager>
 
  #AZURE
  AZURE_OPENAI_API_KEY=<AZURE OPENAI API KEY>


### PR DESCRIPTION
Follow-up to #36. Small env.example cleanup only.

The README's `config.yaml` example loads the AIRS key from `os.environ/PANW_PRISMA_AIRS_API_KEY`, but `env.example` defined `MY_AIRS_API_KEY`. A customer using both files as-is would end up with mismatched variable names and a guardrail that fails to authenticate.

- Renames `MY_AIRS_API_KEY` to `PANW_PRISMA_AIRS_API_KEY` so it matches the README.
- Adds `PANW_PRISMA_AIRS_PROFILE_NAME`, which was missing entirely.

The README rotation-behavior note that was originally part of this PR has been removed pending further testing. Will open a separate PR once the behavior is confirmed end-to-end.