### PR TITLE
fix/MCP AIRS tool_event payloads and transaction IDs

### DIFF
--- a/Anthropic/claude-code-hooks/README.md
+++ b/Anthropic/claude-code-hooks/README.md
@@ -8,7 +8,7 @@ Security hooks for [Claude Code](https://docs.claude.com/en/docs/claude-code) th
 
 | Scanning Phase | Supported | Description |
 |----------------|:---------:|-------------|
-| Prompt | ✅ | Scans user prompts via `UserPromptSubmit` before Claude processes them |
+| Prompt | ✅ | Scans user prompts via `UserPromptSubmit` before Claude Code processes them |
 | Response | ❌ | No model response hook configured |
 | Streaming | ❌ | Not supported |
 | Pre-tool call | ✅ | Scans URLs (WebFetch/WebSearch) and MCP tool inputs via `PreToolUse` |
@@ -28,11 +28,12 @@ User Prompt ──► scan-user-input.sh ──► Claude Code ──► Tool Ca
                                         Tool Execution ───┘
                                              │
                                              ▼
-                                   scan-response-enhanced.sh
-                                   (block: JSON continue:false)
+                         scan-response-enhanced.sh   scan-mcp-response.sh
+                         (web response)             (MCP response)
+                         (block: JSON continue:false)
                                              │
                                              ▼
-                                      Claude Processing
+                                      Claude Code Processing
 ```
 
 ### Security Hooks
@@ -40,11 +41,14 @@ User Prompt ──► scan-user-input.sh ──► Claude Code ──► Tool Ca
 | Script | Hook | Matcher | AIRS Content Type | Blocks via |
 |--------|------|---------|-------------------|------------|
 | `scan-user-input.sh` | `UserPromptSubmit` | — | `prompt` | exit 2 |
-| `scan-url.sh` | `PreToolUse` | `WebFetch\|WebSearch\|web_search` | `prompt` | exit 2 |
+| `scan-url.sh` | `PreToolUse` | `WebFetch\|WebSearch` | `prompt` | exit 2 |
 | `scan-mcp-request.sh` | `PreToolUse` | `mcp__*` | `tool_event` (input only) | exit 2 |
-| `scan-response-enhanced.sh` | `PostToolUse` | `WebFetch\|WebSearch\|web_search`, `mcp__*` | `tool_event` (MCP) or `response` (web) | JSON `continue: false` |
+| `scan-response-enhanced.sh` | `PostToolUse` | `WebFetch\|WebSearch` | `response` | JSON `continue: false` |
+| `scan-mcp-response.sh` | `PostToolUse` | `mcp__*` | `tool_event` (input + output) | JSON `continue: false` |
 
-`scan-response-enhanced.sh` truncates content to 20,000 characters and scans the body. MCP tools use `tool_event` content type; web tools use `response`.
+Hooks send Claude Code `session_id` as the AIRS `transaction_id` for session-level tracing. 
+
+`scan-response-enhanced.sh` truncates web tool response content to 20,000 characters and scans it as `response`. MCP tools use `scan-mcp-response.sh`, which sends compact JSON strings in `tool_event.input` and `tool_event.output` without duplicating the payload as generic `prompt` or `response`.
 
 ---
 
@@ -142,10 +146,10 @@ tail -f .claude/hooks/prisma-airs.log
 
 ## Limitations
 
-- **No model response scanning.** There is no `Stop` or response-phase hook configured. If Claude generates sensitive content (e.g. DLP) without a tool call, it is not scanned.
-- **Content truncation.** `scan-response-enhanced.sh` truncates tool response content to 20,000 characters before scanning.
+- **No model response scanning.** There is no `Stop` or response-phase hook configured. If Claude Code generates sensitive content (e.g. DLP) without a tool call, it is not scanned.
+- **Content truncation.** `scan-response-enhanced.sh` truncates web tool response content to 20,000 characters before scanning. MCP response scans send compact JSON in `tool_event.input` and `tool_event.output`.
 - **Fail-closed on missing config.** All hooks block (exit 2) when `PRISMA_AIRS_API_KEY` or profile is not set. Network/API errors during scanning still fail open.
-- **No timeout on prompt scan.** `scan-user-input.sh` does not set a curl timeout. `scan-response-enhanced.sh` uses 10 seconds.
+- **No timeout on prompt scan.** `scan-user-input.sh` does not set a curl timeout. Response hooks use 10 seconds.
 
 ---
 

--- a/Anthropic/claude-code-hooks/hooks/scan-mcp-request.sh
+++ b/Anthropic/claude-code-hooks/hooks/scan-mcp-request.sh
@@ -41,21 +41,12 @@ TOOL_INPUT=$(echo "$INPUT_JSON" | jq -c '.tool_input // {}' 2>/dev/null)
 MCP_SERVER=$(echo "$TOOL_NAME" | awk -F'__' '{print $2}')
 TOOL_INVOKED=$(echo "$TOOL_NAME" | awk -F'__' '{print $3}')
 
-# Extract transcript_path for session ID (if available)
-TRANSCRIPT_PATH=$(echo "$INPUT_JSON" | jq -r '.transcript_path // empty' 2>/dev/null)
-
-# Generate session UUID
-if [[ -n "$TRANSCRIPT_PATH" ]]; then
-    # Extract session ID from transcript path (e.g., /path/to/.claude/sessions/abc-123/transcript.jsonl)
-    SESSION_ID=$(echo "$TRANSCRIPT_PATH" | sed -E 's/.*\/sessions\/([^\/]+)\/.*/\1/')
-    # If extraction failed, use path hash as fallback
-    if [[ -z "$SESSION_ID" || "$SESSION_ID" == "$TRANSCRIPT_PATH" ]]; then
-        SESSION_ID=$(echo "$TRANSCRIPT_PATH" | md5 | cut -c1-32)
-    fi
-else
-    # Fallback: use working directory hash for session correlation
+# Use Claude Code session_id as the AIRS transaction_id for session-level tracing.
+SESSION_ID=$(echo "$INPUT_JSON" | jq -r '.session_id // empty' 2>/dev/null)
+if [[ -z "$SESSION_ID" ]]; then
     SESSION_ID=$(echo "$PWD" | md5 | cut -c1-32)
 fi
+TRANSACTION_ID="$SESSION_ID"
 
 echo "[$(date)] PreToolUse MCP Hook: Scanning $TOOL_NAME request" >> "$LOG_FILE"
 
@@ -94,10 +85,14 @@ fi
 echo "[$(date)] MCP Request: Scanning '$MCP_REQUEST' for $TOOL_NAME (${#MCP_REQUEST} chars)" >> "$LOG_FILE"
 
 AI_PROFILE_JSON=$(build_ai_profile)
+if [[ -z "$AI_PROFILE_JSON" ]]; then
+    AI_PROFILE_JSON="{}"
+fi
 
 # Create AIRS payload using tool_event for MCP tool scans
 MCP_PAYLOAD=$(jq -n \
-  --arg tr_id "$SESSION_ID" \
+  --arg session_id "$SESSION_ID" \
+  --arg transaction_id "$TRANSACTION_ID" \
   --argjson ai_profile "$AI_PROFILE_JSON" \
   --arg app_user "claude-code-user" \
   --arg app_name "$APP_NAME" \
@@ -105,11 +100,11 @@ MCP_PAYLOAD=$(jq -n \
   --arg tool_invoked "$TOOL_INVOKED" \
   --arg input "$TOOL_INPUT" \
   '{
-    tr_id: $tr_id,
+    session_id: $session_id,
+    transaction_id: $transaction_id,
     ai_profile: $ai_profile,
     metadata: {app_user: $app_user, app_name: $app_name},
     contents: [{
-      prompt: $input,
       tool_event: {
         metadata: {
           ecosystem: "mcp",
@@ -134,10 +129,17 @@ if [[ -n "$SCAN_RESULT" ]]; then
     ACTION=$(echo "$SCAN_RESULT" | jq -r '.action // empty' 2>/dev/null)
     CATEGORY=$(echo "$SCAN_RESULT" | jq -r '.category // empty' 2>/dev/null)
     SCAN_ID=$(echo "$SCAN_RESULT" | jq -r '.scan_id // "unknown"' 2>/dev/null)
+    TOOL_VERDICT=$(echo "$SCAN_RESULT" | jq -r '.tool_detected.verdict // empty' 2>/dev/null)
     
     # Extract ALL detection categories dynamically
     DETECTIONS=""
-    DETECTED_CATEGORIES=$(echo "$SCAN_RESULT" | jq -r '.prompt_detected | to_entries | map(select(.value == true)) | map(.key) | .[]' 2>/dev/null)
+    DETECTED_CATEGORIES=$(echo "$SCAN_RESULT" | jq -r '
+      [
+        (.tool_detected.summary.detections // {} | to_entries[]? | select(.value == true) | .key),
+        (.tool_detected.input_detected.detection_entries // [] | .[] | (.detections // {}) | to_entries[]? | select(.value == true) | .key),
+        (.prompt_detected // {} | to_entries[]? | select(.value == true) | .key)
+      ] | unique | .[]
+    ' 2>/dev/null)
 
     while IFS= read -r category; do
         [[ -z "$category" ]] && continue
@@ -146,7 +148,7 @@ if [[ -n "$SCAN_RESULT" ]]; then
 
     DETECTIONS=$(echo "$DETECTIONS" | sed 's/,$//')
 
-    echo "[$(date)] MCP Request Result: action=$ACTION, category=$CATEGORY" >> "$LOG_FILE"
+    echo "[$(date)] MCP Request Result: action=$ACTION, category=$CATEGORY, tool_verdict=${TOOL_VERDICT:-unknown}" >> "$LOG_FILE"
     
     # Decision logic
     if [[ "$ACTION" == "block" ]]; then
@@ -178,4 +180,3 @@ else
     echo "Prisma AIRS: empty API response — blocking MCP request (fail-closed)" >&2
     exit 2
 fi
-

--- a/Anthropic/claude-code-hooks/hooks/scan-mcp-response.sh
+++ b/Anthropic/claude-code-hooks/hooks/scan-mcp-response.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+LOG_FILE="${SECURITY_LOG_PATH:-.claude/hooks/prisma-airs.log}"
+
+# Ensure log file exists before anything writes to it
+mkdir -p "$(dirname "$LOG_FILE")"
+touch "$LOG_FILE"
+
+# Prisma AIRS API Configuration
+PRISMA_AIRS_API_URL="${PRISMA_AIRS_URL:-https://service.api.aisecurity.paloaltonetworks.com}/v1/scan/sync/request"
+PRISMA_AIRS_API_KEY="${PRISMA_AIRS_API_KEY}"
+PRISMA_AIRS_PROFILE_NAME="${PRISMA_AIRS_PROFILE_NAME:-}"
+PRISMA_AIRS_PROFILE_ID="${PRISMA_AIRS_PROFILE_ID:-}"
+
+# Build ai_profile JSON: prefer profile_id over profile_name
+build_ai_profile() {
+    if [[ -n "$PRISMA_AIRS_PROFILE_ID" ]]; then
+        echo "{\"profile_id\": \"$PRISMA_AIRS_PROFILE_ID\"}"
+    elif [[ -n "$PRISMA_AIRS_PROFILE_NAME" ]]; then
+        echo "{\"profile_name\": \"$PRISMA_AIRS_PROFILE_NAME\"}"
+    else
+        echo "{}"
+    fi
+}
+
+# Set app name with optional custom suffix
+if [[ -n "$CLAUDE_CODE_APP_SUFFIX" ]]; then
+    APP_NAME="Claude Code-${CLAUDE_CODE_APP_SUFFIX}"
+else
+    APP_NAME="Claude Code"
+fi
+
+# Read JSON input from stdin
+INPUT_JSON=$(cat)
+
+# Parse the hook input
+TOOL_NAME=$(echo "$INPUT_JSON" | jq -r '.tool_name // "unknown"')
+
+# Only process MCP tools here. Other tool responses are handled by scan-response-enhanced.sh.
+if [[ "$TOOL_NAME" != mcp__* ]]; then
+    echo "[$(date)] $TOOL_NAME: Skipping non-MCP response in MCP response hook" >> "$LOG_FILE"
+    exit 0
+fi
+
+# Extract server/tool from pattern: mcp__<server>__<tool>
+MCP_SERVER=$(echo "$TOOL_NAME" | awk -F'__' '{print $2}')
+TOOL_INVOKED=$(echo "$TOOL_NAME" | awk -F'__' '{print $3}')
+TOOL_INPUT_STR=$(echo "$INPUT_JSON" | jq -c '.tool_input // {}' 2>/dev/null)
+TOOL_RESPONSE_STR=$(echo "$INPUT_JSON" | jq -c '.tool_response // {}' 2>/dev/null)
+
+if [[ -z "$TOOL_INPUT_STR" || "$TOOL_INPUT_STR" == "null" ]]; then
+    TOOL_INPUT_STR="{}"
+fi
+
+if [[ -z "$TOOL_RESPONSE_STR" || "$TOOL_RESPONSE_STR" == "null" ]]; then
+    TOOL_RESPONSE_STR="{}"
+fi
+
+# Use Claude Code session_id as the AIRS transaction_id for session-level tracing.
+SESSION_ID=$(echo "$INPUT_JSON" | jq -r '.session_id // empty' 2>/dev/null)
+if [[ -z "$SESSION_ID" ]]; then
+    SESSION_ID=$(echo "$PWD" | md5 | cut -c1-32)
+fi
+TRANSACTION_ID="$SESSION_ID"
+
+echo "[$(date)] $TOOL_NAME: MCP PostToolUse hook triggered" >> "$LOG_FILE"
+echo "[$(date)] $TOOL_NAME: MCP input length: ${#TOOL_INPUT_STR}, output length: ${#TOOL_RESPONSE_STR}" >> "$LOG_FILE"
+
+# Skip empty responses.
+if [[ "$TOOL_RESPONSE_STR" == "{}" ]]; then
+    echo "[$(date)] $TOOL_NAME: Skipping - empty MCP response payload" >> "$LOG_FILE"
+    exit 0
+fi
+
+# Fail-closed: block if API key not configured
+if [[ -z "$PRISMA_AIRS_API_KEY" ]]; then
+    echo "[$(date)] ERROR: PRISMA_AIRS_API_KEY not set - blocking MCP response (fail-closed)" >> "$LOG_FILE"
+    echo "Prisma AIRS: API key not configured - blocking MCP response (fail-closed)" >&2
+    exit 2
+fi
+
+AI_PROFILE_JSON=$(build_ai_profile)
+
+CONTENT_PAYLOAD=$(jq -n \
+  --arg session_id "$SESSION_ID" \
+  --arg transaction_id "$TRANSACTION_ID" \
+  --argjson ai_profile "$AI_PROFILE_JSON" \
+  --arg app_user "claude-code-user" \
+  --arg app_name "$APP_NAME" \
+  --arg server_name "$MCP_SERVER" \
+  --arg tool_invoked "$TOOL_INVOKED" \
+  --arg input "$TOOL_INPUT_STR" \
+  --arg output "$TOOL_RESPONSE_STR" \
+  '{
+    session_id: $session_id,
+    transaction_id: $transaction_id,
+    ai_profile: $ai_profile,
+    metadata: {app_user: $app_user, app_name: $app_name},
+    contents: [{
+      tool_event: {
+        metadata: {
+          ecosystem: "mcp",
+          method: "tools/call",
+          server_name: $server_name,
+          tool_invoked: $tool_invoked
+        },
+        input: $input,
+        output: $output
+      }
+    }]
+  }')
+
+# Curl with timeouts and retries
+CURL_OPTS=(--silent --show-error --location --max-time 10 --retry 1)
+CONTENT_RESULT=$(curl "${CURL_OPTS[@]}" "$PRISMA_AIRS_API_URL" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -H "x-pan-token: $PRISMA_AIRS_API_KEY" \
+  -d "$CONTENT_PAYLOAD")
+
+CONTENT_ACTION=$(echo "$CONTENT_RESULT" | jq -r '.action // "unknown"' 2>/dev/null)
+CONTENT_CATEGORY=$(echo "$CONTENT_RESULT" | jq -r '.category // "unknown"' 2>/dev/null)
+CONTENT_SCAN_ID=$(echo "$CONTENT_RESULT" | jq -r '.scan_id // "unknown"' 2>/dev/null)
+TOOL_VERDICT=$(echo "$CONTENT_RESULT" | jq -r '.tool_detected.verdict // empty' 2>/dev/null)
+
+MCP_DETECTIONS=$(echo "$CONTENT_RESULT" | jq -r '
+  [
+    (.tool_detected.summary.detections // {} | to_entries[]? | select(.value == true) | .key),
+    (.tool_detected.input_detected.detection_entries // [] | .[] | (.detections // {}) | to_entries[]? | select(.value == true) | .key),
+    (.tool_detected.output_detected.detection_entries // [] | .[] | (.detections // {}) | to_entries[]? | select(.value == true) | .key),
+    (.prompt_detected // {} | to_entries[]? | select(.value == true) | .key),
+    (.response_detected // {} | to_entries[]? | select(.value == true) | .key)
+  ] | unique | join(",")
+' 2>/dev/null)
+
+if [[ "$CONTENT_ACTION" == "block" ]]; then
+  if [[ -n "$MCP_DETECTIONS" ]]; then
+    echo "[$(date)] BLOCKED MCP response $TOOL_NAME: $CONTENT_CATEGORY - verdict:${TOOL_VERDICT:-unknown} detected: [$MCP_DETECTIONS] [scan:$CONTENT_SCAN_ID]" >> "$LOG_FILE"
+    BLOCK_MSG="Blocked by Prisma AIRS: $TOOL_NAME MCP response contained $CONTENT_CATEGORY content (detected: $MCP_DETECTIONS)"
+  else
+    echo "[$(date)] BLOCKED MCP response $TOOL_NAME: $CONTENT_CATEGORY - verdict:${TOOL_VERDICT:-unknown} [scan:$CONTENT_SCAN_ID]" >> "$LOG_FILE"
+    BLOCK_MSG="Blocked by Prisma AIRS: $TOOL_NAME MCP response contained $CONTENT_CATEGORY content"
+  fi
+  echo "" >&2
+  echo "$BLOCK_MSG" >&2
+  echo "" >&2
+  printf '%s' "$(jq -n --arg msg "$BLOCK_MSG" '{
+  "continue": false,
+  "stopReason": "Prisma AIRS blocked MCP tool response",
+  "systemMessage": $msg,
+  "hookSpecificOutput": { "hookEventName": "PostToolUse" }
+}')"
+  exit 0
+elif [[ "$CONTENT_ACTION" != "allow" && "$CONTENT_ACTION" != "unknown" ]]; then
+  if [[ -n "$MCP_DETECTIONS" ]]; then
+    echo "[$(date)] MCP response warning $TOOL_NAME: $CONTENT_ACTION/$CONTENT_CATEGORY - verdict:${TOOL_VERDICT:-unknown} detected: [$MCP_DETECTIONS] [scan:$CONTENT_SCAN_ID]" >> "$LOG_FILE"
+  else
+    echo "[$(date)] MCP response warning $TOOL_NAME: $CONTENT_ACTION/$CONTENT_CATEGORY - verdict:${TOOL_VERDICT:-unknown} [scan:$CONTENT_SCAN_ID]" >> "$LOG_FILE"
+  fi
+fi
+
+exit 0

--- a/Anthropic/claude-code-hooks/hooks/scan-response-enhanced.sh
+++ b/Anthropic/claude-code-hooks/hooks/scan-response-enhanced.sh
@@ -41,30 +41,19 @@ INPUT_JSON=$(cat)
 TOOL_NAME=$(echo "$INPUT_JSON" | jq -r '.tool_name // "unknown"')
 TOOL_RESPONSE=$(echo "$INPUT_JSON" | jq -r '.tool_response // ""')
 
-# Detect MCP tools and extract server/tool from pattern: mcp__<server>__<tool>
-IS_MCP=false
+# MCP tool responses are handled by scan-mcp-response.sh so they can use
+# AIRS tool_event semantics without generic response duplication.
 if [[ "$TOOL_NAME" == mcp__* ]]; then
-    IS_MCP=true
-    MCP_SERVER=$(echo "$TOOL_NAME" | awk -F'__' '{print $2}')
-    TOOL_INVOKED=$(echo "$TOOL_NAME" | awk -F'__' '{print $3}')
-    TOOL_INPUT_STR=$(echo "$INPUT_JSON" | jq -c '.tool_input // {}' 2>/dev/null)
+    echo "[$(date)] $TOOL_NAME: Skipping MCP response in generic response hook" >> "$LOG_FILE"
+    exit 0
 fi
 
-# Extract transcript_path for session ID (if available)
-TRANSCRIPT_PATH=$(echo "$INPUT_JSON" | jq -r '.transcript_path // empty' 2>/dev/null)
-
-# Generate session UUID
-if [[ -n "$TRANSCRIPT_PATH" ]]; then
-    # Extract session ID from transcript path (e.g., /path/to/.claude/sessions/abc-123/transcript.jsonl)
-    SESSION_ID=$(echo "$TRANSCRIPT_PATH" | sed -E 's/.*\/sessions\/([^\/]+)\/.*/\1/')
-    # If extraction failed, use path hash as fallback
-    if [[ -z "$SESSION_ID" || "$SESSION_ID" == "$TRANSCRIPT_PATH" ]]; then
-        SESSION_ID=$(echo "$TRANSCRIPT_PATH" | md5 | cut -c1-32)
-    fi
-else
-    # Fallback: use working directory hash for session correlation
+# Use Claude Code session_id as the AIRS transaction_id for session-level tracing.
+SESSION_ID=$(echo "$INPUT_JSON" | jq -r '.session_id // empty' 2>/dev/null)
+if [[ -z "$SESSION_ID" ]]; then
     SESSION_ID=$(echo "$PWD" | md5 | cut -c1-32)
 fi
+TRANSACTION_ID="$SESSION_ID"
 
 # Log that we're processing this tool
 echo "[$(date)] 🔍 $TOOL_NAME: PostToolUse hook triggered" >> "$LOG_FILE"
@@ -121,53 +110,26 @@ fi
 # Scan response content if reasonable size (truncate and optimize)
 TRUNCATED_CONTENT="$(echo "$RESPONSE_CONTENT" | head -c 20000 | tr '\n' ' ')"
 if [[ ${#TRUNCATED_CONTENT} -ge 10 ]]; then
-    if [[ "$IS_MCP" == true ]]; then
-        # Use tool_event for MCP tools (includes input + output)
-        AI_PROFILE_JSON=$(build_ai_profile)
-        CONTENT_PAYLOAD=$(jq -n \
-          --arg tr_id "$SESSION_ID" \
-          --argjson ai_profile "$AI_PROFILE_JSON" \
-          --arg app_user "claude-code-user" \
-          --arg app_name "$APP_NAME" \
-          --arg server_name "$MCP_SERVER" \
-          --arg tool_invoked "$TOOL_INVOKED" \
-          --arg input "$TOOL_INPUT_STR" \
-          --arg output "$TRUNCATED_CONTENT" \
-          '{
-            tr_id: $tr_id,
-            ai_profile: $ai_profile,
-            metadata: {app_user: $app_user, app_name: $app_name},
-            contents: [{
-              response: $output,
-              tool_event: {
-                metadata: {
-                  ecosystem: "mcp",
-                  method: "tools/call",
-                  server_name: $server_name,
-                  tool_invoked: $tool_invoked
-                },
-                input: $input,
-                output: $output
-              }
-            }]
-          }')
-    else
-        # Use jq for safe JSON construction (no raw variable interpolation)
-        AI_PROFILE_JSON=$(build_ai_profile)
-        CONTENT_PAYLOAD=$(jq -n \
-          --arg tr_id "$SESSION_ID" \
-          --argjson ai_profile "$AI_PROFILE_JSON" \
-          --arg app_user "claude-code-user" \
-          --arg app_name "$APP_NAME" \
-          --arg tool_name "$TOOL_NAME" \
-          --arg response "$TRUNCATED_CONTENT" \
-          '{
-            tr_id: $tr_id,
-            ai_profile: $ai_profile,
-            metadata: {app_user: $app_user, app_name: $app_name, tool_name: $tool_name, source: "response-content"},
-            contents: [{response: $response}]
-          }')
+    # Use jq for safe JSON construction (no raw variable interpolation)
+    AI_PROFILE_JSON=$(build_ai_profile)
+    if [[ -z "$AI_PROFILE_JSON" ]]; then
+        AI_PROFILE_JSON="{}"
     fi
+    CONTENT_PAYLOAD=$(jq -n \
+      --arg session_id "$SESSION_ID" \
+      --arg transaction_id "$TRANSACTION_ID" \
+      --argjson ai_profile "$AI_PROFILE_JSON" \
+      --arg app_user "claude-code-user" \
+      --arg app_name "$APP_NAME" \
+      --arg tool_name "$TOOL_NAME" \
+      --arg response "$TRUNCATED_CONTENT" \
+      '{
+        session_id: $session_id,
+        transaction_id: $transaction_id,
+        ai_profile: $ai_profile,
+        metadata: {app_user: $app_user, app_name: $app_name, tool_name: $tool_name, source: "response-content"},
+        contents: [{response: $response}]
+      }')
 
     # Curl with timeouts and retries
     CURL_OPTS=(--silent --show-error --location --max-time 10 --retry 1)

--- a/Anthropic/claude-code-hooks/hooks/scan-url.sh
+++ b/Anthropic/claude-code-hooks/hooks/scan-url.sh
@@ -61,18 +61,12 @@ if [[ -z "$URL" ]]; then
     exit 0  # Allow if no URL found
 fi
 
-# Extract transcript_path for session ID (if available)
-TRANSCRIPT_PATH=$(echo "$INPUT_JSON" | jq -r '.transcript_path // empty' 2>/dev/null)
-
-# Generate session UUID
-if [[ -n "$TRANSCRIPT_PATH" ]]; then
-    SESSION_ID=$(echo "$TRANSCRIPT_PATH" | sed -E 's/.*\/sessions\/([^\/]+)\/.*/\1/')
-    if [[ -z "$SESSION_ID" || "$SESSION_ID" == "$TRANSCRIPT_PATH" ]]; then
-        SESSION_ID=$(echo "$TRANSCRIPT_PATH" | md5 | cut -c1-32)
-    fi
-else
+# Use Claude Code session_id as the AIRS transaction_id for session-level tracing.
+SESSION_ID=$(echo "$INPUT_JSON" | jq -r '.session_id // empty' 2>/dev/null)
+if [[ -z "$SESSION_ID" ]]; then
     SESSION_ID=$(echo "$PWD" | md5 | cut -c1-32)
 fi
+TRANSACTION_ID="$SESSION_ID"
 
 echo "[$(date)] 🌐 $TOOL_NAME: $URL" >> "$LOG_FILE"
 
@@ -80,7 +74,8 @@ AI_PROFILE=$(build_ai_profile)
 
 # Create JSON payload for URL scanning
 PAYLOAD=$(jq -n \
-  --arg tr_id "$SESSION_ID" \
+  --arg session_id "$SESSION_ID" \
+  --arg transaction_id "$TRANSACTION_ID" \
   --argjson ai_profile "$AI_PROFILE" \
   --arg app_user "claude-code-user" \
   --arg app_name "$APP_NAME" \
@@ -88,7 +83,8 @@ PAYLOAD=$(jq -n \
   --arg source "pre-tool-use" \
   --arg url "$URL" \
   '{
-    tr_id: $tr_id,
+    session_id: $session_id,
+    transaction_id: $transaction_id,
     ai_profile: $ai_profile,
     metadata: {app_user: $app_user, app_name: $app_name, tool_name: $tool_name, source: $source},
     contents: [{prompt: $url}]

--- a/Anthropic/claude-code-hooks/hooks/scan-user-input.sh
+++ b/Anthropic/claude-code-hooks/hooks/scan-user-input.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Prisma AIRS User Input Security Scanner Hook for Claude Code
-# Scans URLs in user messages BEFORE they reach Claude
+# Scans URLs in user messages BEFORE Claude Code processes them
 # This provides first-line defense against malicious URLs
 
 # Configuration with environment variable support
@@ -61,31 +61,27 @@ if [[ -z "$USER_MESSAGE" ]]; then
     exit 0  # Allow if no prompt found
 fi
 
-# Extract transcript_path for session ID (if available)
-TRANSCRIPT_PATH=$(echo "$INPUT_JSON" | jq -r '.transcript_path // empty' 2>/dev/null)
-
-# Generate session UUID
-if [[ -n "$TRANSCRIPT_PATH" ]]; then
-    SESSION_ID=$(echo "$TRANSCRIPT_PATH" | sed -E 's/.*\/sessions\/([^\/]+)\/.*/\1/')
-    if [[ -z "$SESSION_ID" || "$SESSION_ID" == "$TRANSCRIPT_PATH" ]]; then
-        SESSION_ID=$(echo "$TRANSCRIPT_PATH" | md5 | cut -c1-32)
-    fi
-else
+# Use Claude Code session_id as the AIRS transaction_id for session-level tracing.
+SESSION_ID=$(echo "$INPUT_JSON" | jq -r '.session_id // empty' 2>/dev/null)
+if [[ -z "$SESSION_ID" ]]; then
     SESSION_ID=$(echo "$PWD" | md5 | cut -c1-32)
 fi
+TRANSACTION_ID="$SESSION_ID"
 
 AI_PROFILE=$(build_ai_profile)
 
 # Create payload to scan the entire user message
 PAYLOAD=$(jq -n \
-  --arg tr_id "$SESSION_ID" \
+  --arg session_id "$SESSION_ID" \
+  --arg transaction_id "$TRANSACTION_ID" \
   --argjson ai_profile "$AI_PROFILE" \
   --arg app_user "claude-code-user" \
   --arg app_name "$APP_NAME" \
   --arg source "user-prompt-submit" \
   --arg prompt "$USER_MESSAGE" \
   '{
-    tr_id: $tr_id,
+    session_id: $session_id,
+    transaction_id: $transaction_id,
     ai_profile: $ai_profile,
     metadata: {app_user: $app_user, app_name: $app_name, source: $source},
     contents: [{prompt: $prompt}]

--- a/Anthropic/claude-code-hooks/settings.json
+++ b/Anthropic/claude-code-hooks/settings.json
@@ -23,7 +23,7 @@
         ]
       },
       {
-        "matcher": "mcp__.*__read.*|mcp__.*__resource.*|mcp__.*",
+        "matcher": "mcp__.*",
         "hooks": [
           {
             "type": "command",
@@ -43,11 +43,11 @@
         ]
       },
       {
-        "matcher": "mcp__.*__read.*|mcp__.*__resource.*|mcp__.*",
+        "matcher": "mcp__.*",
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/hooks/scan-response-enhanced.sh"
+            "command": "~/.claude/hooks/scan-mcp-response.sh"
           }
         ]
       }


### PR DESCRIPTION
## Description

Fix Claude Code AIRS hooks to scan MCP payloads via tool_event and correlate scans by Claude Code session_id

## Motivation and Context

send MCP data only as 'tool_event' payloads
update tr_id to transaction_id

## How Has This Been Tested?

Manual testing

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
