### PR TITLE
feat: add Cloud Run provisioning pipelines for AIRS-on-Apigee (Google/cloudrun)

### DIFF
--- a/Google/cloudrun/README.md
+++ b/Google/cloudrun/README.md
@@ -1,0 +1,55 @@
+# Google Cloud Run — AIRS-on-Apigee provisioning pipelines
+
+Git-push-driven, **Cloud Build → Cloud Run Job** automation that provisions the
+Prisma AIRS + Vertex AI on Apigee X reference patterns end to end (enable APIs,
+create the Vertex service account + IAM bindings, configure the encrypted KVM,
+import + deploy the Apigee bundles). The sibling [`../apigee`](../apigee) folder
+holds the **manual** bundles + deploy scripts; this folder automates deploying
+them with no manual `gcloud`/`curl` steps.
+
+Two self-contained pipelines — clone the repo and run whichever fits:
+
+| Folder | Pattern | Best for |
+|--------|---------|----------|
+| [`flow/`](flow) | **SharedFlow** — reusable `PANW-AIRS` flow + thin `vertex-airs-sync` proxy | Many proxies/LLMs sharing one AIRS posture |
+| [`proxy/`](proxy) | **Monolithic** — self-contained `vertex-simple` (scan + DLP masking baked in) | A single LLM proxy; simplest footprint |
+
+Both: scan prompt + response via the AIRS sync API, return a graceful block on
+malicious content (prompt never reaches Vertex), support DLP masking when the
+AIRS profile enables it, and call Vertex as a dedicated service account (with
+the Apigee `tokenCreator` binding wired automatically).
+
+## Self-contained by design
+
+Each pipeline carries its **own copy** of the Apigee bundles under its
+`bundles/` folder, rather than referencing the canonical bundles in
+[`../apigee`](../apigee):
+
+- `flow/bundles/` ↔ `../apigee/sharedflow/` (`PANW-AIRS`, `vertex-airs-sync`)
+- `proxy/bundles/vertex-simple/` ↔ `../apigee/apiproxy/`
+
+This is deliberate: it keeps each pipeline a complete **clone-and-run** unit and
+lets the Docker build context be the pipeline folder only (no reaching across
+the repo). The trade-off is that each bundle exists in two places — when you
+change a canonical bundle in `../apigee`, update the matching copy here.
+
+## Quick start
+
+```bash
+cd flow      # or: cd proxy
+cat README.md
+./setup/bootstrap.sh --project=YOUR_PROJECT_ID --region=us-central1
+```
+
+Each pipeline gets its own Cloud Build trigger pointed at that folder's
+`cloudbuild.yaml` (e.g. `--build-config=Google/cloudrun/flow/cloudbuild.yaml`).
+The GitHub-App connection is 1st-gen, so triggers are created with
+`--region=global` while resources deploy to `_REGION` (default `us-central1`).
+See each folder's README for the full bootstrap → trigger → push flow.
+
+## Prerequisites
+
+An Apigee X org (evaluation is fine), a Prisma AIRS API token + security
+profile, and an account with Owner (or equivalent) on the GCP project to run
+the one-time `bootstrap.sh`. The Vertex service account and its IAM bindings are
+created by the pipeline.

--- a/Google/cloudrun/flow/Dockerfile
+++ b/Google/cloudrun/flow/Dockerfile
@@ -1,0 +1,22 @@
+# Provisioner image for the AIRS-on-Apigee Cloud Run Job.
+#
+# Base: Google Cloud SDK (slim) — ships gcloud + bash + curl. We add jq and
+# zip, which provision.sh needs to build the Apigee bundle archives and parse
+# the management-API JSON responses.
+
+FROM google/cloud-sdk:slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends jq zip \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# The provisioning script and the Apigee bundles it deploys.
+COPY provision.sh /app/provision.sh
+COPY bundles/ /app/bundles/
+
+RUN chmod +x /app/provision.sh
+
+# The Job runs the script to completion and exits. No long-running process.
+ENTRYPOINT ["/app/provision.sh"]

--- a/Google/cloudrun/flow/README.md
+++ b/Google/cloudrun/flow/README.md
@@ -1,0 +1,148 @@
+# AIRS-on-Apigee Provisioning Pipeline
+
+A GCP-native CI/CD pipeline that provisions the **Prisma AIRS + Vertex AI on Apigee X** reference pattern from a git push — enable APIs, create the Vertex service account, configure the encrypted KVM, and import + deploy the SharedFlow and proxy, all in one automated run.
+
+This is the automation layer for the SharedFlow reference bundles published under [`Google/apigee/sharedflow`](../../apigee/sharedflow).
+
+> **Self-contained by design.** This pipeline keeps its **own copy** of the
+> `PANW-AIRS` SharedFlow + `vertex-airs-sync` proxy bundles under [`bundles/`](bundles/)
+> rather than referencing `Google/apigee/sharedflow/`, so each Cloud Run pipeline
+> is a complete clone-and-run unit (the Docker build context is this folder only).
+> Trade-off: the bundles live in two places — keep this copy in sync with the
+> canonical one in `Google/apigee/sharedflow/` when that changes.
+
+## How it works
+
+```
+  git push to main
+        │
+        ▼
+  ┌─────────────────────┐
+  │  Cloud Build        │   reads cloudbuild.yaml
+  │  (the pipeline)     │
+  │                     │
+  │  1. docker build    │   builds the provisioner image
+  │  2. docker push     │   → Artifact Registry
+  │  3. run jobs deploy │   create/update the Cloud Run Job
+  │  4. run jobs execute│   run it, wait, fail the build if it fails
+  └─────────┬───────────┘
+            │
+            ▼
+  ┌─────────────────────────────────────┐
+  │  Cloud Run Job (provision.sh)       │
+  │                                     │
+  │  1. enable GCP APIs                 │
+  │  2. create/verify Vertex SA + IAM   │
+  │  3. (guarded) create AIRS profile   │
+  │  4. upsert encrypted Apigee KVM     │
+  │  5. import + deploy SharedFlow      │
+  │  6. import + deploy sync proxy      │
+  └─────────────────────────────────────┘
+```
+
+A few terms, since the pieces are GCP-specific:
+
+- **Cloud Build** is GCP's CI engine. It reads `cloudbuild.yaml` and runs the steps in order. A *trigger* connects it to your git repo so a push starts a build.
+- **Artifact Registry** is GCP's container image store — the pipeline's equivalent of Docker Hub.
+- **A Cloud Run Job** is a container that runs once, to completion, then exits (unlike a Cloud Run *Service*, which stays up serving HTTP). Our `provision.sh` is a run-once task, so a Job is the right fit.
+- **Secret Manager** holds the AIRS token. The Job reads it at runtime; it never lives in the repo or in an image.
+
+Why a Job rather than running `provision.sh` directly inside Cloud Build? The Job is a **reusable, independently-runnable unit** — once deployed you can re-run provisioning from the console, on a schedule, or from another system, without a git push. Cloud Build just builds it and kicks off the first run.
+
+## Repository layout
+
+```
+airs-apigee-pipeline/
+├── cloudbuild.yaml        # the 4-step pipeline
+├── Dockerfile             # the provisioner image (cloud-sdk + jq + zip)
+├── provision.sh           # runs inside the Job — does the actual provisioning
+├── pipeline.env.example   # documented config (Cloud Build substitutions)
+├── setup/
+│   └── bootstrap.sh       # ONE-TIME manual setup — run this first
+└── bundles/
+    ├── PANW-AIRS/         # the AIRS-call SharedFlow
+    └── vertex-airs-sync/  # the synchronous Vertex proxy
+```
+
+## Prerequisites
+
+- An **existing Apigee X organization** with an environment and an env group. The pipeline configures *within* an org — it does not create one (org creation is a ~45-minute, one-time operation).
+- A **Prisma AIRS** tenant with a security profile and an API token.
+- `gcloud` installed locally (only for the one-time `bootstrap.sh`).
+- Permission to run `bootstrap.sh` — Owner or equivalent on the GCP project.
+
+## Setup — three steps
+
+### 1. Run the one-time bootstrap
+
+```bash
+./setup/bootstrap.sh \
+  --project=YOUR_PROJECT_ID \
+  --region=us-central1 \
+  --airs-token=PANW-xxxxxxxx
+```
+
+This enables APIs, creates the Artifact Registry repo, creates the `airs-api-token` Secret Manager secret (seeded with `--airs-token`), creates the runtime service account, and grants both the runtime SA and the Cloud Build SA their roles. It is idempotent — safe to re-run.
+
+If you omit `--airs-token`, the secret is created empty and you add the value yourself:
+
+```bash
+printf '%s' 'PANW-xxxxxxxx' | gcloud secrets versions add airs-api-token --data-file=- --project YOUR_PROJECT_ID
+```
+
+### 2. Connect the repo and create the trigger
+
+Connecting a GitHub repo to Cloud Build is a one-time OAuth flow in the console: **Cloud Build → Triggers → Connect Repository**. Once connected, create the trigger (`bootstrap.sh` prints this command filled in for you):
+
+```bash
+gcloud builds triggers create github \
+  --project=YOUR_PROJECT_ID \
+  --region=global \
+  --name=airs-apigee-pipeline \
+  --repo-name=YOUR_REPO_NAME \
+  --repo-owner=YOUR_GITHUB_USERNAME \
+  --branch-pattern='^main$' \
+  --build-config=Google/cloudrun/flow/cloudbuild.yaml \
+  --service-account=projects/YOUR_PROJECT_ID/serviceAccounts/airs-pipeline-sa@YOUR_PROJECT_ID.iam.gserviceaccount.com \
+  --substitutions=_REGION=us-central1,_RUNTIME_SA=airs-pipeline-sa@YOUR_PROJECT_ID.iam.gserviceaccount.com,_APIGEE_ORG=YOUR_PROJECT_ID,_APIGEE_ENV=eval,_VERTEX_SA=apigee-vertex-sa@YOUR_PROJECT_ID.iam.gserviceaccount.com,_AIRS_PROFILE=YOUR_AIRS_PROFILE,_ENVGROUP_HOSTNAME=YOUR_ENVGROUP_HOSTNAME
+```
+
+> **`--service-account` is required under a user-managed-SA org policy.** If your org enforces it (common in enterprise orgs), omitting this flag fails with a bare `INVALID_ARGUMENT` from the API — no field named. We reuse the runtime SA as the build identity (`bootstrap.sh` step 5 grants it the build roles), so one SA covers both build and Job.
+
+> **`--region=global` is deliberate.** If you connected the repo via the GitHub App ("Install Google Cloud Build"), that is a **1st-gen, global** connection — the trigger must be created in `global`. Passing a regional value (e.g. `us-central1`) makes `gcloud` look for a 2nd-gen connection that does not exist and fails with *"repository not found."* This is separate from `_REGION`, which controls where the **resources** (Artifact Registry, Cloud Run Job) deploy — trigger location and resource location are independent.
+
+`_VERTEX_SA` can be any SA email — the pipeline **creates it** if it doesn't exist. `_ENVGROUP_HOSTNAME` is optional and only enables the smoke-test URL in the run summary. See `pipeline.env.example` for every substitution variable and what it does.
+
+### 3. Push to `main`
+
+That's it. Every push to `main` now runs the pipeline. Watch it under **Cloud Build → History**; watch the provisioning output under **Cloud Run → Jobs → airs-apigee-provisioner → Logs**.
+
+## Configuration
+
+All deployment-specific values are **Cloud Build substitution variables**, set on the trigger. None are hardcoded. See [`pipeline.env.example`](pipeline.env.example) for the full list with descriptions.
+
+The only secret — the AIRS API token — lives in Secret Manager as `airs-api-token` and is injected into the Job at deploy time. It is never in the repo, the image, or the build logs.
+
+## Optional — AIRS security-profile creation
+
+By default the pipeline assumes your AIRS security profile already exists. To have it create the profile via the AIRS management API instead:
+
+1. Add an `airs-mgmt-token` secret (Secret Manager) with a management-API token.
+2. In `cloudbuild.yaml`, add to the `deploy-job` step's args:
+   - `--set-secrets=...,AIRS_MGMT_TOKEN=airs-mgmt-token:latest`
+   - `--set-env-vars=...,AIRS_MGMT_API=<management API base URL>`
+3. Set the `_CREATE_AIRS_PROFILE=1` substitution.
+
+`provision.sh`'s `maybe_create_airs_profile()` is the seam — verify the exact endpoint and payload against [pan.dev](https://pan.dev/prisma-airs/) before relying on it.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Build fails at `push` step | Cloud Build SA missing `artifactregistry.writer` | Re-run `bootstrap.sh`; confirm the right Cloud Build SA via `--cloud-build-sa` |
+| Build fails at `deploy-job` step with a permissions error | Cloud Build SA can't act as the runtime SA | Re-run `bootstrap.sh` — it grants `iam.serviceAccountUser` |
+| Job fails: `AIRS_TOKEN not set` | The `airs-api-token` secret has no value | Add a secret version (see Setup step 1) |
+| Job fails: Apigee `403` | Runtime SA missing `apigee.admin`, or wrong Apigee org | Re-run `bootstrap.sh`; check the `_APIGEE_ORG` substitution |
+| Job fails enabling APIs | Runtime SA missing `serviceUsageAdmin` | Re-run `bootstrap.sh` |
+
+Cloud Build → History shows each build; click into a build to see per-step logs. The Job's own output (the provisioning phases) is in Cloud Run → Jobs → Logs, or linked from the `execute-job` build step.

--- a/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/PANW-AIRS.xml
+++ b/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/PANW-AIRS.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<SharedFlowBundle revision="1" name="PANW-AIRS">
+    <DisplayName>PANW-AIRS</DisplayName>
+    <Description>PANW AIRS sync scan SharedFlow. JSON.stringify-based body builder safely handles quotes/newlines in prompts and model responses.</Description>
+    <SharedFlows>
+        <SharedFlow>default</SharedFlow>
+    </SharedFlows>
+    <subType>SharedFlow</subType>
+</SharedFlowBundle>

--- a/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/policies/AM-SetAIRSScanRequest.xml
+++ b/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/policies/AM-SetAIRSScanRequest.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  Materialises a fresh outbound HTTP request message (airsScanRequest)
+  for the ServiceCallout. The payload is interpolated at the message body
+  level from the pre-built JSON string in airsScanRequestBody — so the JSON
+  is constructed once by JSON.stringify and never re-escaped.
+-->
+<AssignMessage continueOnError="false" enabled="true" name="AM-SetAIRSScanRequest">
+  <DisplayName>AM-SetAIRSScanRequest</DisplayName>
+  <Properties/>
+  <AssignTo createNew="true" transport="http" type="request">airsScanRequest</AssignTo>
+  <Set>
+    <Verb>POST</Verb>
+    <Headers>
+      <Header name="Content-Type">application/json</Header>
+      <Header name="x-pan-token">{airs.token}</Header>
+    </Headers>
+    <Payload contentType="application/json">{airsScanRequestBody}</Payload>
+  </Set>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</AssignMessage>

--- a/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/policies/EV-ParseAIRSVerdict.xml
+++ b/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/policies/EV-ParseAIRSVerdict.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  Parses the AIRS scan response.
+
+  Top-level fields:
+    airs.action    -> "allow" | "block"
+    airs.category  -> "malicious" | "benign"   (umbrella verdict)
+    airs.scan_id        -> AIRS scan identifier for audit cross-reference
+    airs.transaction_id -> echo of transaction_id sent in request
+
+  Per-detector booleans (note: AIRS only populates the side relevant to the
+  scan that was just performed — prompt_detected on input scans,
+  response_detected on output scans). The SharedFlow uses these to route to
+  category-specific RaiseFault policies. JSONPath extracts booleans as the
+  strings "true" / "false", so conditions compare against "true".
+
+    prompt_detected.injection      -> airs.prompt.injection
+    prompt_detected.dlp            -> airs.prompt.dlp
+    prompt_detected.url_cats       -> airs.prompt.url_cats
+    prompt_detected.toxic_content  -> airs.prompt.toxic_content
+
+    response_detected.dlp             -> airs.response.dlp
+    response_detected.url_cats        -> airs.response.url_cats
+    response_detected.malicious_code  -> airs.response.malicious_code
+    response_detected.toxic_content   -> airs.response.toxic_content
+    response_detected.db_security     -> airs.response.db_security
+    response_detected.ungrounded      -> airs.response.ungrounded
+-->
+<ExtractVariables continueOnError="false" enabled="true" name="EV-ParseAIRSVerdict">
+  <DisplayName>EV-ParseAIRSVerdict</DisplayName>
+  <Properties/>
+  <Source>airsScanResponse</Source>
+  <JSONPayload>
+    <Variable name="airs.action">
+      <JSONPath>$.action</JSONPath>
+    </Variable>
+    <Variable name="airs.category">
+      <JSONPath>$.category</JSONPath>
+    </Variable>
+    <Variable name="airs.scan_id">
+      <JSONPath>$.scan_id</JSONPath>
+    </Variable>
+    <Variable name="airs.transaction_id">
+      <JSONPath>$.transaction_id</JSONPath>
+    </Variable>
+
+    <Variable name="airs.prompt.injection">
+      <JSONPath>$.prompt_detected.injection</JSONPath>
+    </Variable>
+    <Variable name="airs.prompt.dlp">
+      <JSONPath>$.prompt_detected.dlp</JSONPath>
+    </Variable>
+    <Variable name="airs.prompt.url_cats">
+      <JSONPath>$.prompt_detected.url_cats</JSONPath>
+    </Variable>
+    <Variable name="airs.prompt.toxic_content">
+      <JSONPath>$.prompt_detected.toxic_content</JSONPath>
+    </Variable>
+
+    <Variable name="airs.response.dlp">
+      <JSONPath>$.response_detected.dlp</JSONPath>
+    </Variable>
+    <Variable name="airs.response.url_cats">
+      <JSONPath>$.response_detected.url_cats</JSONPath>
+    </Variable>
+    <Variable name="airs.response.malicious_code">
+      <JSONPath>$.response_detected.malicious_code</JSONPath>
+    </Variable>
+    <Variable name="airs.response.toxic_content">
+      <JSONPath>$.response_detected.toxic_content</JSONPath>
+    </Variable>
+    <Variable name="airs.response.db_security">
+      <JSONPath>$.response_detected.db_security</JSONPath>
+    </Variable>
+    <Variable name="airs.response.ungrounded">
+      <JSONPath>$.response_detected.ungrounded</JSONPath>
+    </Variable>
+
+    <!-- Masked/redacted content AIRS returns when the profile has masking
+         enabled. Present on allow verdicts; the calling proxy (which knows the
+         LLM payload shape) writes these back into the request/response body.
+         prompt_masked_data on input scans, response_masked_data on output. -->
+    <Variable name="airs.prompt.redacted">
+      <JSONPath>$.prompt_masked_data.data</JSONPath>
+    </Variable>
+    <Variable name="airs.response.redacted">
+      <JSONPath>$.response_masked_data.data</JSONPath>
+    </Variable>
+  </JSONPayload>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</ExtractVariables>

--- a/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/policies/JS-BuildAIRSScanBody.xml
+++ b/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/policies/JS-BuildAIRSScanBody.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  Builds the AIRS sync/request JSON body using JSON.stringify so prompts /
+  model responses containing quotes, newlines or backslashes get escaped
+  safely. Branches on the FlowCallout "type" parameter:
+    type = "user-prompt"      -> uses request_prompt_value, field "prompt"
+    type = "response-prompt"  -> uses response_prompt_value, field "response"
+  Writes the final JSON string to airsScanRequestBody.
+-->
+<Javascript continueOnError="false" enabled="true" timeLimit="200" name="JS-BuildAIRSScanBody">
+  <DisplayName>JS-BuildAIRSScanBody</DisplayName>
+  <Properties/>
+  <ResourceURL>jsc://build-airs-scan-body.js</ResourceURL>
+</Javascript>

--- a/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/policies/KVM-GetAIRSConfig.xml
+++ b/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/policies/KVM-GetAIRSConfig.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<KeyValueMapOperations continueOnError="false" enabled="true" name="KVM-GetAIRSConfig" mapIdentifier="airs-config">
+  <DisplayName>KVM-GetAIRSConfig</DisplayName>
+  <Properties/>
+  <ExpiryTimeInSecs>300</ExpiryTimeInSecs>
+  <Get assignTo="airs.token">
+    <Key>
+      <Parameter>airs_token</Parameter>
+    </Key>
+  </Get>
+  <Get assignTo="airs.profile">
+    <Key>
+      <Parameter>airs_profile</Parameter>
+    </Key>
+  </Get>
+  <Scope>environment</Scope>
+</KeyValueMapOperations>

--- a/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/policies/RF-DLP-Detected.xml
+++ b/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/policies/RF-DLP-Detected.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RaiseFault continueOnError="false" enabled="true" name="RF-DLP-Detected">
+  <DisplayName>RF-DLP-Detected</DisplayName>
+  <Properties/>
+  <FaultResponse>
+    <Set>
+      <Payload contentType="application/json">{"candidates":[{"content":{"role":"model","parts":[{"text":"Your prompt or the model's response contains sensitive data (PII) that is not allowed for privacy and compliance reasons. The content has been blocked by Palo Alto AIRS."}]},"finishReason":"STOP"}],"modelVersion":"{model}","airs":{"action":"block","category":"dlp","scan_id":"{airs.scan_id}"}}</Payload>
+      <StatusCode>200</StatusCode>
+      <ReasonPhrase>OK</ReasonPhrase>
+    </Set>
+  </FaultResponse>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/policies/RF-Generic-Block.xml
+++ b/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/policies/RF-Generic-Block.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  Catch-all RaiseFault. Fires when AIRS returns action=block with a category
+  we don't have a specific handler for. Surfaces the AIRS category in the
+  airs metadata so the caller can log what was detected.
+-->
+<RaiseFault continueOnError="false" enabled="true" name="RF-Generic-Block">
+  <DisplayName>RF-Generic-Block</DisplayName>
+  <Properties/>
+  <FaultResponse>
+    <Set>
+      <Payload contentType="application/json">{"candidates":[{"content":{"role":"model","parts":[{"text":"The content has been blocked by Palo Alto AIRS. Reason category: {airs.category}."}]},"finishReason":"STOP"}],"modelVersion":"{model}","airs":{"action":"block","category":"{airs.category}","scan_id":"{airs.scan_id}"}}</Payload>
+      <StatusCode>200</StatusCode>
+      <ReasonPhrase>OK</ReasonPhrase>
+    </Set>
+  </FaultResponse>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/policies/RF-MaliciousCode-Detected.xml
+++ b/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/policies/RF-MaliciousCode-Detected.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RaiseFault continueOnError="false" enabled="true" name="RF-MaliciousCode-Detected">
+  <DisplayName>RF-MaliciousCode-Detected</DisplayName>
+  <Properties/>
+  <FaultResponse>
+    <Set>
+      <Payload contentType="application/json">{"candidates":[{"content":{"role":"model","parts":[{"text":"The content contains malicious or potentially harmful code constructs and has been blocked by Palo Alto AIRS."}]},"finishReason":"STOP"}],"modelVersion":"{model}","airs":{"action":"block","category":"malicious-code","scan_id":"{airs.scan_id}"}}</Payload>
+      <StatusCode>200</StatusCode>
+      <ReasonPhrase>OK</ReasonPhrase>
+    </Set>
+  </FaultResponse>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/policies/RF-MaliciousURL-Detected.xml
+++ b/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/policies/RF-MaliciousURL-Detected.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RaiseFault continueOnError="false" enabled="true" name="RF-MaliciousURL-Detected">
+  <DisplayName>RF-MaliciousURL-Detected</DisplayName>
+  <Properties/>
+  <FaultResponse>
+    <Set>
+      <Payload contentType="application/json">{"candidates":[{"content":{"role":"model","parts":[{"text":"The content contains a URL classified as malicious or unsafe and has been blocked by Palo Alto AIRS."}]},"finishReason":"STOP"}],"modelVersion":"{model}","airs":{"action":"block","category":"malicious-url","scan_id":"{airs.scan_id}"}}</Payload>
+      <StatusCode>200</StatusCode>
+      <ReasonPhrase>OK</ReasonPhrase>
+    </Set>
+  </FaultResponse>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/policies/RF-PromptInjection-Detected.xml
+++ b/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/policies/RF-PromptInjection-Detected.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RaiseFault continueOnError="false" enabled="true" name="RF-PromptInjection-Detected">
+  <DisplayName>RF-PromptInjection-Detected</DisplayName>
+  <Properties/>
+  <FaultResponse>
+    <Set>
+      <Payload contentType="application/json">{"candidates":[{"content":{"role":"model","parts":[{"text":"Your prompt has been flagged as a potential prompt injection or jailbreak attempt by Palo Alto AIRS. An administrative review has been logged for your account."}]},"finishReason":"STOP"}],"modelVersion":"{model}","airs":{"action":"block","category":"prompt-injection","scan_id":"{airs.scan_id}"}}</Payload>
+      <StatusCode>200</StatusCode>
+      <ReasonPhrase>OK</ReasonPhrase>
+    </Set>
+  </FaultResponse>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/policies/RF-Toxic-Detected.xml
+++ b/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/policies/RF-Toxic-Detected.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RaiseFault continueOnError="false" enabled="true" name="RF-Toxic-Detected">
+  <DisplayName>RF-Toxic-Detected</DisplayName>
+  <Properties/>
+  <FaultResponse>
+    <Set>
+      <Payload contentType="application/json">{"candidates":[{"content":{"role":"model","parts":[{"text":"The content contains toxic, abusive, or otherwise inappropriate language and has been blocked by Palo Alto AIRS."}]},"finishReason":"STOP"}],"modelVersion":"{model}","airs":{"action":"block","category":"toxic-content","scan_id":"{airs.scan_id}"}}</Payload>
+      <StatusCode>200</StatusCode>
+      <ReasonPhrase>OK</ReasonPhrase>
+    </Set>
+  </FaultResponse>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/policies/SC-AIRSScan.xml
+++ b/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/policies/SC-AIRSScan.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  Calls the AIRS sync scan API.
+  Uses the request message built by AM-BuildAIRSRequest-Input or -Output.
+  AIRS authenticates via the x-pan-token header (not GoogleAccessToken).
+-->
+<ServiceCallout continueOnError="false" enabled="true" name="SC-AIRSScan">
+  <DisplayName>SC-AIRSScan</DisplayName>
+  <Request variable="airsScanRequest">
+    <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+  </Request>
+  <Response>airsScanResponse</Response>
+  <Timeout>5000</Timeout>
+  <HTTPTargetConnection>
+    <URL>https://service.api.aisecurity.paloaltonetworks.com/v1/scan/sync/request</URL>
+    <Properties/>
+  </HTTPTargetConnection>
+</ServiceCallout>

--- a/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/resources/jsc/build-airs-scan-body.js
+++ b/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/resources/jsc/build-airs-scan-body.js
@@ -1,0 +1,31 @@
+// Build the AIRS sync/request JSON body safely.
+// Branches on FlowCallout parameter "type":
+//   "user-prompt"     -> uses request_prompt_value, content.prompt
+//   "response-prompt" -> uses response_prompt_value, content.response
+// JSON.stringify handles quotes, newlines, backslashes, unicode etc.
+
+var type = context.getVariable('type');
+var profile = context.getVariable('airs.profile');
+// Apigee's messageid is unique per request — a transaction identifier.
+var transactionId = context.getVariable('messageid');
+var model = context.getVariable('model');
+
+var content = {};
+if (type === 'response-prompt') {
+    content.response = context.getVariable('response_prompt_value') || '';
+} else {
+    content.prompt = context.getVariable('request_prompt_value') || '';
+}
+
+var body = {
+    transaction_id: transactionId || '',
+    ai_profile: { profile_name: profile || '' },
+    metadata: {
+        ai_model: model || 'unknown',
+        app_user: 'apigee-shared-flow',
+        app_name: 'Apigee-SharedFlow'
+    },
+    contents: [content]
+};
+
+context.setVariable('airsScanRequestBody', JSON.stringify(body));

--- a/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/sharedflows/default.xml
+++ b/Google/cloudrun/flow/bundles/PANW-AIRS/sharedflowbundle/sharedflows/default.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<SharedFlow name="default">
+  <!-- 1. Pull AIRS token + profile from env-scoped KVM (airs-config) -->
+  <Step>
+    <Name>KVM-GetAIRSConfig</Name>
+  </Step>
+
+  <!-- 2. Build the AIRS scan body in JS using JSON.stringify (safe for quotes, newlines, etc.) -->
+  <Step>
+    <Name>JS-BuildAIRSScanBody</Name>
+  </Step>
+
+  <!-- 3. Set the outbound HTTP request (verb, headers, payload from variable) -->
+  <Step>
+    <Name>AM-SetAIRSScanRequest</Name>
+  </Step>
+
+  <!-- 4. POST to AIRS sync/request endpoint -->
+  <Step>
+    <Name>SC-AIRSScan</Name>
+  </Step>
+
+  <!-- 5. Parse verdict: action, category, scan_id + per-detector booleans -->
+  <Step>
+    <Name>EV-ParseAIRSVerdict</Name>
+  </Step>
+
+  <!-- 6. Category-specific blocks (Vertex-shaped 200 OK responses so calling apps
+       need no special handling). Conditions inspect the per-detector booleans
+       which AIRS returns under prompt_detected / response_detected — these are
+       the granular signals; airs.category is just the umbrella malicious/benign. -->
+  <Step>
+    <Name>RF-PromptInjection-Detected</Name>
+    <Condition>airs.action = "block" and airs.prompt.injection = "true"</Condition>
+  </Step>
+  <Step>
+    <Name>RF-DLP-Detected</Name>
+    <Condition>airs.action = "block" and (airs.prompt.dlp = "true" or airs.response.dlp = "true")</Condition>
+  </Step>
+  <Step>
+    <Name>RF-MaliciousCode-Detected</Name>
+    <Condition>airs.action = "block" and airs.response.malicious_code = "true"</Condition>
+  </Step>
+  <Step>
+    <Name>RF-MaliciousURL-Detected</Name>
+    <Condition>airs.action = "block" and (airs.prompt.url_cats = "true" or airs.response.url_cats = "true")</Condition>
+  </Step>
+  <Step>
+    <Name>RF-Toxic-Detected</Name>
+    <Condition>airs.action = "block" and (airs.prompt.toxic_content = "true" or airs.response.toxic_content = "true")</Condition>
+  </Step>
+
+  <!-- 7. Catch-all: AIRS blocked but no specific RF matched (e.g. db_security,
+       ungrounded, or any future detector we haven't wired a tailored response for). -->
+  <Step>
+    <Name>RF-Generic-Block</Name>
+    <Condition>airs.action = "block"</Condition>
+  </Step>
+</SharedFlow>

--- a/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/policies/AM-SetTarget.xml
+++ b/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/policies/AM-SetTarget.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<AssignMessage continueOnError="false" enabled="true" name="AM-SetTarget">
+  <DisplayName>AM-SetTarget</DisplayName>
+  <Properties/>
+  <AssignVariable>
+    <Name>targetUrl</Name>
+    <Value>https://{region}-aiplatform.googleapis.com/{proxy.pathsuffix}</Value>
+  </AssignVariable>
+  <AssignVariable>
+    <Name>target.url</Name>
+    <Template ref="targetUrl"/>
+  </AssignVariable>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</AssignMessage>

--- a/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/policies/EV-ExtractFields.xml
+++ b/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/policies/EV-ExtractFields.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ExtractVariables continueOnError="false" enabled="true" name="EV-ExtractFields">
+    <DisplayName>EV-ExtractFields</DisplayName>
+    <Properties/>
+    <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+    <URIPath>
+        <Pattern ignoreCase="false">/v1/projects/{projectId}/locations/{region}/publishers/{modelProvider}/models/{model}:generateContent</Pattern>
+    </URIPath>
+    <Source clearPayload="false">request</Source>
+</ExtractVariables>

--- a/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/policies/FC-CallAIRSInput.xml
+++ b/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/policies/FC-CallAIRSInput.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  FlowCallout into PANW-AIRS with type=user-prompt.
+  Used in the request path to scan the user prompt before invoking Vertex.
+-->
+<FlowCallout continueOnError="false" enabled="true" name="FC-CallAIRSInput">
+  <DisplayName>FC-CallAIRSInput</DisplayName>
+  <FaultRules/>
+  <Parameters>
+    <Parameter name="type">user-prompt</Parameter>
+  </Parameters>
+  <SharedFlowBundle>PANW-AIRS</SharedFlowBundle>
+</FlowCallout>

--- a/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/policies/FC-CallAIRSOutput.xml
+++ b/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/policies/FC-CallAIRSOutput.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  FlowCallout into PANW-AIRS with type=response-prompt.
+  Used in the response path to scan the model output before returning to client.
+-->
+<FlowCallout continueOnError="false" enabled="true" name="FC-CallAIRSOutput">
+  <DisplayName>FC-CallAIRSOutput</DisplayName>
+  <FaultRules/>
+  <Parameters>
+    <Parameter name="type">response-prompt</Parameter>
+  </Parameters>
+  <SharedFlowBundle>PANW-AIRS</SharedFlowBundle>
+</FlowCallout>

--- a/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/policies/JS-ApplyPromptMasking.xml
+++ b/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/policies/JS-ApplyPromptMasking.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Javascript continueOnError="false" enabled="true" timeLimit="200" name="JS-ApplyPromptMasking">
+  <DisplayName>JS-ApplyPromptMasking</DisplayName>
+  <ResourceURL>jsc://apply-prompt-masking.js</ResourceURL>
+</Javascript>

--- a/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/policies/JS-ApplyResponseMasking.xml
+++ b/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/policies/JS-ApplyResponseMasking.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Javascript continueOnError="false" enabled="true" timeLimit="200" name="JS-ApplyResponseMasking">
+  <DisplayName>JS-ApplyResponseMasking</DisplayName>
+  <ResourceURL>jsc://apply-response-masking.js</ResourceURL>
+</Javascript>

--- a/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/policies/JS-ExtractRequestPrompt.xml
+++ b/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/policies/JS-ExtractRequestPrompt.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  Parses the incoming Vertex generateContent request body and joins
+  contents[*].parts[*].text into a single string assigned to
+  request_prompt_value. JSON.parse handles whatever escaping was on the wire.
+-->
+<Javascript continueOnError="false" enabled="true" timeLimit="200" name="JS-ExtractRequestPrompt">
+  <DisplayName>JS-ExtractRequestPrompt</DisplayName>
+  <Properties/>
+  <ResourceURL>jsc://extract-request-prompt.js</ResourceURL>
+</Javascript>

--- a/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/policies/JS-ExtractResponsePrompt.xml
+++ b/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/policies/JS-ExtractResponsePrompt.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  Parses the Vertex generateContent response body and joins
+  candidates[0].content.parts[*].text into a single string assigned to
+  response_prompt_value. This is the fix for the v1 400-from-AIRS bug:
+  the v1 AssignMessage template stuffed multi-paragraph model text with
+  quotes/newlines directly inside a JSON string literal, breaking the body.
+-->
+<Javascript continueOnError="false" enabled="true" timeLimit="200" name="JS-ExtractResponsePrompt">
+  <DisplayName>JS-ExtractResponsePrompt</DisplayName>
+  <Properties/>
+  <ResourceURL>jsc://extract-response-prompt.js</ResourceURL>
+</Javascript>

--- a/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/proxies/default.xml
+++ b/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/proxies/default.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ProxyEndpoint name="default">
+    <Description/>
+    <FaultRules/>
+    <PreFlow name="PreFlow">
+        <Request>
+            <Step>
+                <Name>EV-ExtractFields</Name>
+            </Step>
+            <Step>
+                <Name>JS-ExtractRequestPrompt</Name>
+            </Step>
+            <Step>
+                <Name>FC-CallAIRSInput</Name>
+            </Step>
+            <Step>
+                <!-- If AIRS returned a masked prompt (profile masking on), write
+                     it back into the Vertex request before the target call. -->
+                <Name>JS-ApplyPromptMasking</Name>
+            </Step>
+        </Request>
+        <Response>
+            <Step>
+                <Name>JS-ExtractResponsePrompt</Name>
+            </Step>
+            <Step>
+                <Name>FC-CallAIRSOutput</Name>
+            </Step>
+            <Step>
+                <!-- If AIRS returned masked model output, write it back into
+                     the Vertex response before returning to the client. -->
+                <Name>JS-ApplyResponseMasking</Name>
+            </Step>
+        </Response>
+    </PreFlow>
+    <Flows/>
+    <PostFlow name="PostFlow">
+        <Request/>
+        <Response/>
+    </PostFlow>
+    <HTTPProxyConnection>
+        <BasePath>/vertex-airs-sync</BasePath>
+        <Properties/>
+    </HTTPProxyConnection>
+    <RouteRule name="llm">
+        <TargetEndpoint>llm</TargetEndpoint>
+    </RouteRule>
+</ProxyEndpoint>

--- a/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/resources/jsc/apply-prompt-masking.js
+++ b/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/resources/jsc/apply-prompt-masking.js
@@ -1,0 +1,32 @@
+// Apply the masked prompt AIRS returned (when the profile enables masking)
+// before the request reaches Vertex. The PANW-AIRS SharedFlow stays payload-
+// agnostic — it only exposes airs.prompt.redacted as a string. This policy,
+// which lives in the Vertex proxy, is the one that knows the Vertex request
+// shape (contents[].parts[].text) and writes the redacted text back in.
+var action = context.getVariable('airs.action');
+var redactedPrompt = context.getVariable('airs.prompt.redacted');
+
+// Only on an allow verdict that carried masked content. A block verdict is
+// handled by the SharedFlow's RF-* policies and never reaches the target.
+if (action === 'allow' && redactedPrompt) {
+  try {
+    var requestObj = JSON.parse(context.getVariable('request.content'));
+    if (requestObj.contents && Array.isArray(requestObj.contents)) {
+      for (var i = 0; i < requestObj.contents.length; i++) {
+        var parts = requestObj.contents[i].parts;
+        if (parts && Array.isArray(parts)) {
+          for (var j = 0; j < parts.length; j++) {
+            if (parts[j].text) {
+              parts[j].text = redactedPrompt;
+            }
+          }
+        }
+      }
+    }
+    context.setVariable('request.content', JSON.stringify(requestObj));
+    context.setVariable('airs.prompt.masking.applied', 'true');
+  } catch (e) {
+    // Don't fail the request on a masking error — send the original prompt.
+    print('Error applying prompt masking: ' + e);
+  }
+}

--- a/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/resources/jsc/apply-response-masking.js
+++ b/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/resources/jsc/apply-response-masking.js
@@ -1,0 +1,30 @@
+// Apply the masked model output AIRS returned (when the profile enables
+// masking) before the response goes back to the client. Mirror of
+// apply-prompt-masking.js for the response side: the SharedFlow exposes
+// airs.response.redacted as a string; this policy knows the Vertex response
+// shape (candidates[].content.parts[].text) and writes the redacted text in.
+var action = context.getVariable('airs.action');
+var redactedResponse = context.getVariable('airs.response.redacted');
+
+if (action === 'allow' && redactedResponse) {
+  try {
+    var responseObj = JSON.parse(context.getVariable('response.content'));
+    if (responseObj.candidates && Array.isArray(responseObj.candidates)) {
+      for (var i = 0; i < responseObj.candidates.length; i++) {
+        var content = responseObj.candidates[i].content;
+        if (content && content.parts && Array.isArray(content.parts)) {
+          for (var j = 0; j < content.parts.length; j++) {
+            if (content.parts[j].text) {
+              content.parts[j].text = redactedResponse;
+            }
+          }
+        }
+      }
+    }
+    context.setVariable('response.content', JSON.stringify(responseObj));
+    context.setVariable('airs.response.masking.applied', 'true');
+  } catch (e) {
+    // Don't fail the response on a masking error — return the original output.
+    print('Error applying response masking: ' + e);
+  }
+}

--- a/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/resources/jsc/extract-request-prompt.js
+++ b/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/resources/jsc/extract-request-prompt.js
@@ -1,0 +1,30 @@
+// Parse the Vertex generateContent request body and flatten all user-supplied
+// text into request_prompt_value (single string). Multi-turn / multi-part
+// messages are joined with newlines so AIRS scans the whole conversation.
+
+var raw = context.getVariable('request.content');
+var text = '';
+
+try {
+    if (raw) {
+        var body = JSON.parse(raw);
+        var parts = [];
+        if (body && body.contents) {
+            for (var i = 0; i < body.contents.length; i++) {
+                var entry = body.contents[i];
+                if (entry && entry.parts) {
+                    for (var j = 0; j < entry.parts.length; j++) {
+                        if (entry.parts[j] && typeof entry.parts[j].text === 'string') {
+                            parts.push(entry.parts[j].text);
+                        }
+                    }
+                }
+            }
+        }
+        text = parts.join('\n');
+    }
+} catch (e) {
+    text = '';
+}
+
+context.setVariable('request_prompt_value', text);

--- a/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/resources/jsc/extract-response-prompt.js
+++ b/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/resources/jsc/extract-response-prompt.js
@@ -1,0 +1,28 @@
+// Parse the Vertex generateContent response body and flatten all model-emitted
+// text into response_prompt_value (single string). Joined with newlines so the
+// AIRS output scan sees the full model response, properly escaped downstream.
+
+var raw = context.getVariable('response.content');
+var text = '';
+
+try {
+    if (raw) {
+        var body = JSON.parse(raw);
+        if (body && body.candidates && body.candidates.length > 0) {
+            var content = body.candidates[0].content;
+            if (content && content.parts) {
+                var parts = [];
+                for (var i = 0; i < content.parts.length; i++) {
+                    if (content.parts[i] && typeof content.parts[i].text === 'string') {
+                        parts.push(content.parts[i].text);
+                    }
+                }
+                text = parts.join('\n');
+            }
+        }
+    }
+} catch (e) {
+    text = '';
+}
+
+context.setVariable('response_prompt_value', text);

--- a/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/targets/llm.xml
+++ b/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/targets/llm.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<TargetEndpoint name="llm">
+    <Description/>
+    <FaultRules/>
+    <PreFlow name="PreFlow">
+        <Request/>
+        <Response/>
+    </PreFlow>
+    <PostFlow name="PostFlow">
+        <Request>
+            <Step>
+                <Name>AM-SetTarget</Name>
+            </Step>
+        </Request>
+        <Response/>
+    </PostFlow>
+    <HTTPTargetConnection>
+        <Authentication>
+            <GoogleAccessToken>
+                <Scopes>
+                    <Scope>https://www.googleapis.com/auth/cloud-platform</Scope>
+                </Scopes>
+            </GoogleAccessToken>
+        </Authentication>
+        <Properties/>
+        <URL>https://{target.url}</URL>
+    </HTTPTargetConnection>
+</TargetEndpoint>

--- a/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/vertex-airs-sync.xml
+++ b/Google/cloudrun/flow/bundles/vertex-airs-sync/apiproxy/vertex-airs-sync.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<APIProxy revision="1" name="vertex-airs-sync">
+    <DisplayName>vertex-airs-sync</DisplayName>
+    <Description>Synchronous Apigee proxy invoking the PANW-AIRS SharedFlow on both request and response, fronting Vertex AI generateContent. JS-based prompt extraction safely handles multi-paragraph payloads.</Description>
+</APIProxy>

--- a/Google/cloudrun/flow/cloudbuild.yaml
+++ b/Google/cloudrun/flow/cloudbuild.yaml
@@ -1,0 +1,80 @@
+# Cloud Build pipeline — AIRS-on-Apigee provisioning.
+#
+# Fires on every push to the connected branch (trigger created by
+# setup/bootstrap.sh). Four steps:
+#   1. Build the provisioner Docker image
+#   2. Push it to Artifact Registry
+#   3. Create/update the Cloud Run Job with the new image
+#   4. Execute the Job and wait — the build fails if provisioning fails
+#
+# All deployment-specific values are substitution variables (see
+# pipeline.env.example). Secrets are NOT here — the AIRS token is injected
+# into the Job from Secret Manager at step 3.
+
+substitutions:
+  _REGION: us-central1
+  _AR_REPO: airs-apigee
+  _JOB_NAME: airs-apigee-provisioner
+  _RUNTIME_SA: ""              # SA the Cloud Run Job runs as (from bootstrap.sh)
+  _APIGEE_ORG: ""              # Apigee org; empty → provision.sh defaults to PROJECT_ID
+  _APIGEE_ENV: eval
+  _VERTEX_SA: ""               # Vertex caller SA email (created if missing)
+  _AIRS_PROFILE: ""            # AIRS security profile name
+  _ENVGROUP_HOSTNAME: ""       # optional — enables smoke-test URL in the summary
+  _CREATE_AIRS_PROFILE: "0"    # "1" opts into AIRS profile creation via mgmt API
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+
+steps:
+  # 1 — build the provisioner image (context = Google/cloudrun/flow/; the trigger
+  # checks out the repo root, so point the Docker build at this subfolder)
+  - id: build
+    name: gcr.io/cloud-builders/docker
+    dir: Google/cloudrun/flow
+    args:
+      - build
+      - -t
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/provisioner:$BUILD_ID
+      - -t
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/provisioner:latest
+      - .
+
+  # 2 — push both tags to Artifact Registry
+  - id: push
+    name: gcr.io/cloud-builders/docker
+    args:
+      - push
+      - --all-tags
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/provisioner
+
+  # 3 — create or update the Cloud Run Job with the fresh image
+  - id: deploy-job
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    args:
+      - run
+      - jobs
+      - deploy
+      - ${_JOB_NAME}
+      - --image=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/provisioner:latest
+      - --region=${_REGION}
+      - --service-account=${_RUNTIME_SA}
+      - --set-env-vars=PROJECT=$PROJECT_ID,REGION=${_REGION},APIGEE_ORG=${_APIGEE_ORG},APIGEE_ENV=${_APIGEE_ENV},VERTEX_SA=${_VERTEX_SA},AIRS_PROFILE=${_AIRS_PROFILE},ENVGROUP_HOSTNAME=${_ENVGROUP_HOSTNAME},CREATE_AIRS_PROFILE=${_CREATE_AIRS_PROFILE}
+      - --set-secrets=AIRS_TOKEN=airs-api-token:latest
+      - --max-retries=0
+      - --task-timeout=900s
+
+  # 4 — run the Job; --wait makes this step (and the build) fail if it fails
+  - id: execute-job
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    args:
+      - run
+      - jobs
+      - execute
+      - ${_JOB_NAME}
+      - --region=${_REGION}
+      - --wait
+
+timeout: 1800s

--- a/Google/cloudrun/flow/pipeline.env.example
+++ b/Google/cloudrun/flow/pipeline.env.example
@@ -1,0 +1,57 @@
+# Pipeline configuration reference.
+#
+# These are the Cloud Build SUBSTITUTION VARIABLES that parameterize the
+# pipeline. They are NOT loaded as a file at runtime — they are set on the
+# Cloud Build trigger (see setup/bootstrap.sh step 6) or passed ad hoc with:
+#
+#     gcloud builds submit --substitutions=_KEY=value,_KEY2=value2 ...
+#
+# Copy this file to pipeline.env, fill it in, and keep it for your own
+# reference. pipeline.env is gitignored — never commit real values.
+
+# --- Required ---------------------------------------------------------------
+
+# Apigee environment to deploy into.
+_APIGEE_ENV=eval
+
+# Service account email the Apigee proxy uses to call Vertex AI.
+# Created automatically by provision.sh if it does not exist.
+_VERTEX_SA=apigee-vertex-sa@YOUR_PROJECT_ID.iam.gserviceaccount.com
+
+# AIRS security profile name the SharedFlow scans against.
+_AIRS_PROFILE=YOUR_AIRS_PROFILE
+
+# Service account the Cloud Run Job runs as (created by bootstrap.sh).
+_RUNTIME_SA=airs-pipeline-sa@YOUR_PROJECT_ID.iam.gserviceaccount.com
+
+# --- Optional (have sensible defaults in cloudbuild.yaml) -------------------
+
+# GCP region for Artifact Registry, Cloud Run, and Vertex. Default: us-central1
+_REGION=us-central1
+
+# Artifact Registry repo name. Default: airs-apigee
+_AR_REPO=airs-apigee
+
+# Cloud Run Job name. Default: airs-apigee-provisioner
+_JOB_NAME=airs-apigee-provisioner
+
+# Apigee org. Leave empty to default to the GCP project ID.
+_APIGEE_ORG=
+
+# Env-group hostname. If set, the provisioning summary prints a ready-to-run
+# smoke-test curl. Optional.
+_ENVGROUP_HOSTNAME=
+
+# Set to "1" to have provision.sh create the AIRS security profile via the
+# management API. Requires AIRS_MGMT_API + an AIRS_MGMT_TOKEN secret wired
+# into the Job. Default "0" — assumes the profile already exists.
+_CREATE_AIRS_PROFILE=0
+
+# --- Secrets (NOT substitution variables) -----------------------------------
+#
+# The AIRS scan token lives in Secret Manager as `airs-api-token` and is
+# injected into the Job by cloudbuild.yaml (--set-secrets). Never put it here.
+#
+# If _CREATE_AIRS_PROFILE=1 you also need an `airs-mgmt-token` secret and must
+# add --set-secrets=AIRS_MGMT_TOKEN=airs-mgmt-token:latest plus an
+# AIRS_MGMT_API env var to the Job.

--- a/Google/cloudrun/flow/provision.sh
+++ b/Google/cloudrun/flow/provision.sh
@@ -1,0 +1,319 @@
+#!/usr/bin/env bash
+# provision.sh — full provisioning of the AIRS-on-Apigee reference pattern.
+#
+# Runs inside the Cloud Run Job container. All configuration arrives as
+# environment variables (set on the Job by cloudbuild.yaml; secrets injected
+# from Secret Manager). There are no CLI arguments.
+#
+# Phases:
+#   1. Enable required GCP APIs
+#   2. Create / verify the Vertex service account + IAM bindings
+#   3. (guarded) Create / verify the AIRS security profile via the mgmt API
+#   4. Upsert the encrypted Apigee KVM `airs-config`
+#   5. Import + deploy the PANW-AIRS SharedFlow
+#   6. Import + deploy the vertex-airs-sync proxy
+#
+# Every phase is idempotent — safe to re-run on every pipeline trigger.
+
+set -euo pipefail
+
+# ----- config from environment ----------------------------------------------
+
+PROJECT="${PROJECT:-}"
+REGION="${REGION:-us-central1}"
+APIGEE_ORG="${APIGEE_ORG:-$PROJECT}"
+APIGEE_ENV="${APIGEE_ENV:-}"
+VERTEX_SA="${VERTEX_SA:-}"
+AIRS_PROFILE="${AIRS_PROFILE:-}"
+AIRS_TOKEN="${AIRS_TOKEN:-}"
+ENVGROUP_HOSTNAME="${ENVGROUP_HOSTNAME:-}"
+
+# Guarded optional: AIRS security-profile creation. Off unless explicitly set.
+CREATE_AIRS_PROFILE="${CREATE_AIRS_PROFILE:-0}"
+AIRS_MGMT_TOKEN="${AIRS_MGMT_TOKEN:-}"
+AIRS_MGMT_API="${AIRS_MGMT_API:-}"
+
+# ----- constants ------------------------------------------------------------
+
+SHAREDFLOW_NAME="PANW-AIRS"
+SYNC_PROXY_NAME="vertex-airs-sync"
+SHAREDFLOW_SRC="/app/bundles/PANW-AIRS"
+SYNC_PROXY_SRC="/app/bundles/vertex-airs-sync"
+KVM_NAME="airs-config"
+APIGEE_API="https://apigee.googleapis.com/v1"
+
+REQUIRED_APIS=(
+  apigee.googleapis.com
+  aiplatform.googleapis.com
+  iam.googleapis.com
+  serviceusage.googleapis.com
+)
+
+# ----- output helpers -------------------------------------------------------
+
+step() { printf "\n\033[1;34m▶ %s\033[0m\n" "$*"; }
+ok()   { printf "  \033[32m✓\033[0m %s\n" "$*"; }
+warn() { printf "  \033[33m!\033[0m %s\n" "$*"; }
+die()  { printf "  \033[31m✗\033[0m %s\n" "$*" >&2; exit 1; }
+
+# ----- validation -----------------------------------------------------------
+
+[[ -n "$PROJECT"      ]] || die "PROJECT not set"
+[[ -n "$APIGEE_ENV"   ]] || die "APIGEE_ENV not set"
+[[ -n "$VERTEX_SA"    ]] || die "VERTEX_SA not set"
+[[ -n "$AIRS_PROFILE" ]] || die "AIRS_PROFILE not set"
+[[ -n "$AIRS_TOKEN"   ]] || die "AIRS_TOKEN not set (expected from Secret Manager)"
+
+command -v gcloud >/dev/null || die "gcloud not on PATH"
+command -v jq     >/dev/null || die "jq not on PATH"
+command -v zip    >/dev/null || die "zip not on PATH"
+command -v curl   >/dev/null || die "curl not on PATH"
+
+[[ -d "$SHAREDFLOW_SRC" ]] || die "Missing bundle dir $SHAREDFLOW_SRC"
+[[ -d "$SYNC_PROXY_SRC" ]] || die "Missing bundle dir $SYNC_PROXY_SRC"
+
+# The Job runs as a service account; gcloud picks up credentials from the
+# metadata server automatically. This token is reused for all Apigee calls.
+gcloud config set project "$PROJECT" --quiet >/dev/null 2>&1
+TOKEN="$(gcloud auth print-access-token)"
+[[ -n "$TOKEN" ]] || die "gcloud auth print-access-token returned empty"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ----- Apigee mgmt API helpers ----------------------------------------------
+
+api() {
+  local method="$1" path="$2" body="${3:-}"
+  local extra_args=("-sS" "-X" "$method" "-H" "Authorization: Bearer $TOKEN")
+  if [[ -n "$body" ]]; then
+    extra_args+=("-H" "Content-Type: application/json" "--data" "$body")
+  fi
+  extra_args+=("-w" "\n%{http_code}")
+  curl "${extra_args[@]}" "$APIGEE_API$path"
+}
+
+api_status() {
+  curl -sS -o /dev/null -w "%{http_code}" \
+    -H "Authorization: Bearer $TOKEN" "$APIGEE_API$1"
+}
+
+# ----- phase 1: enable APIs -------------------------------------------------
+
+enable_apis() {
+  step "Phase 1 — enabling required GCP APIs"
+  # Single batched call; gcloud no-ops APIs already enabled.
+  gcloud services enable "${REQUIRED_APIS[@]}" --project "$PROJECT" --quiet
+  for a in "${REQUIRED_APIS[@]}"; do ok "$a"; done
+}
+
+# ----- phase 2: Vertex service account --------------------------------------
+
+ensure_vertex_sa() {
+  step "Phase 2 — Vertex service account"
+
+  local sa_id="${VERTEX_SA%%@*}"   # account id = part before '@'
+
+  if gcloud iam service-accounts describe "$VERTEX_SA" \
+       --project "$PROJECT" >/dev/null 2>&1; then
+    ok "Service account $VERTEX_SA exists"
+  else
+    gcloud iam service-accounts create "$sa_id" \
+      --project "$PROJECT" \
+      --display-name "Apigee → Vertex AI caller (AIRS pipeline)" --quiet
+    ok "Service account $VERTEX_SA created"
+  fi
+
+  # roles/aiplatform.user lets the Apigee proxy call Vertex as this SA.
+  # add-iam-policy-binding is idempotent — re-adding an existing binding no-ops.
+  gcloud projects add-iam-policy-binding "$PROJECT" \
+    --member "serviceAccount:$VERTEX_SA" \
+    --role "roles/aiplatform.user" \
+    --condition=None --quiet >/dev/null
+  ok "roles/aiplatform.user bound to $VERTEX_SA"
+
+  # At RUNTIME the Apigee data plane impersonates this SA to mint the Google
+  # access token for the Vertex TargetEndpoint (<Authentication><GoogleAccessToken>).
+  # Impersonation requires the Apigee service agent to be a Token Creator ON
+  # this SA — without it the proxy returns HTTP 500 GoogleTokenGenerationFailure.
+  # (Deploy-time actAs is separate and not sufficient for runtime token minting.)
+  local proj_num apigee_agent
+  proj_num="$(gcloud projects describe "$PROJECT" --format='value(projectNumber)')"
+  apigee_agent="service-${proj_num}@gcp-sa-apigee.iam.gserviceaccount.com"
+  gcloud iam service-accounts add-iam-policy-binding "$VERTEX_SA" \
+    --member "serviceAccount:$apigee_agent" \
+    --role "roles/iam.serviceAccountTokenCreator" \
+    --project "$PROJECT" --quiet >/dev/null
+  ok "roles/iam.serviceAccountTokenCreator: $apigee_agent → $VERTEX_SA"
+}
+
+# ----- phase 3: AIRS security profile (guarded optional) --------------------
+
+maybe_create_airs_profile() {
+  step "Phase 3 — AIRS security profile"
+
+  if [[ "$CREATE_AIRS_PROFILE" != "1" ]]; then
+    ok "CREATE_AIRS_PROFILE not set — assuming profile '$AIRS_PROFILE' already exists"
+    return 0
+  fi
+
+  # Opt-in path. Requires the AIRS management API base URL + a management
+  # token (separate from the runtime scan token). Verify the exact endpoint
+  # and payload schema against https://pan.dev/prisma-airs/ before relying on
+  # this in production.
+  [[ -n "$AIRS_MGMT_API"   ]] || die "CREATE_AIRS_PROFILE=1 but AIRS_MGMT_API not set"
+  [[ -n "$AIRS_MGMT_TOKEN" ]] || die "CREATE_AIRS_PROFILE=1 but AIRS_MGMT_TOKEN not set"
+
+  local resp code body
+  resp="$(curl -sS -X POST \
+    -H "Authorization: Bearer $AIRS_MGMT_TOKEN" \
+    -H "Content-Type: application/json" \
+    -w "\n%{http_code}" \
+    --data "$(jq -n --arg n "$AIRS_PROFILE" '{name:$n}')" \
+    "$AIRS_MGMT_API/v1/ai-security-profiles")"
+  code="${resp##*$'\n'}"
+  body="${resp%$'\n'*}"
+
+  if [[ "$code" =~ ^(200|201)$ ]]; then
+    ok "AIRS security profile '$AIRS_PROFILE' created"
+  elif [[ "$code" == "409" ]]; then
+    ok "AIRS security profile '$AIRS_PROFILE' already exists"
+  else
+    die "AIRS profile create failed (HTTP $code): $body"
+  fi
+}
+
+# ----- phase 4: KVM ---------------------------------------------------------
+
+setup_kvm() {
+  step "Phase 4 — encrypted KVM $KVM_NAME in env=$APIGEE_ENV"
+
+  local kvm_path="/organizations/$APIGEE_ORG/environments/$APIGEE_ENV/keyvaluemaps/$KVM_NAME"
+  local status
+  status="$(api_status "$kvm_path")"
+
+  if [[ "$status" == "200" ]]; then
+    ok "KVM $KVM_NAME exists"
+  else
+    local body code
+    body="$(api POST "/organizations/$APIGEE_ORG/environments/$APIGEE_ENV/keyvaluemaps" \
+              "$(jq -n --arg n "$KVM_NAME" '{name:$n, encrypted:true}')")"
+    code="${body##*$'\n'}"
+    [[ "$code" =~ ^(200|201)$ ]] || die "KVM create failed (HTTP $code): $body"
+    ok "KVM $KVM_NAME created (encrypted)"
+  fi
+
+  for entry in "airs_token:$AIRS_TOKEN" "airs_profile:$AIRS_PROFILE"; do
+    local key="${entry%%:*}" val="${entry#*:}"
+    local entry_path="$kvm_path/entries/$key"
+    local entry_status payload resp code
+    entry_status="$(api_status "$entry_path")"
+    payload="$(jq -n --arg n "$key" --arg v "$val" '{name:$n, value:$v}')"
+
+    if [[ "$entry_status" == "200" ]]; then
+      resp="$(api PUT "$entry_path" "$payload")"
+      code="${resp##*$'\n'}"
+      [[ "$code" =~ ^(200|201)$ ]] || die "KVM entry update $key failed (HTTP $code): $resp"
+      ok "KVM entry $key updated"
+    else
+      resp="$(api POST "$kvm_path/entries" "$payload")"
+      code="${resp##*$'\n'}"
+      [[ "$code" =~ ^(200|201)$ ]] || die "KVM entry create $key failed (HTTP $code): $resp"
+      ok "KVM entry $key created"
+    fi
+  done
+}
+
+# ----- bundle helpers -------------------------------------------------------
+
+zip_sharedflow() { ( cd "$1" && zip -qr "$2" sharedflowbundle -x "*.DS_Store" ); }
+zip_proxy()      { ( cd "$1" && zip -qr "$2" apiproxy        -x "*.DS_Store" ); }
+
+import_bundle() {
+  local kind="$1" name="$2" zip="$3"   # kind = sharedflows | apis
+  local resp code body rev
+  resp="$(curl -sS -X POST \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: multipart/form-data" \
+    -F "file=@$zip" \
+    -w "\n%{http_code}" \
+    "$APIGEE_API/organizations/$APIGEE_ORG/$kind?action=import&name=$name")"
+  code="${resp##*$'\n'}"
+  body="${resp%$'\n'*}"
+  [[ "$code" =~ ^(200|201)$ ]] || die "Bundle import failed (HTTP $code): $body"
+  rev="$(echo "$body" | jq -r '.revision // empty')"
+  [[ -n "$rev" ]] || die "No revision returned in import response: $body"
+  echo "$rev"
+}
+
+deploy_revision() {
+  local kind="$1" name="$2" rev="$3" sa="${4:-}"
+  local path="/organizations/$APIGEE_ORG/environments/$APIGEE_ENV/$kind/$name/revisions/$rev/deployments?override=true"
+  # Apigee deployments API query param is `serviceAccount` (NOT
+  # `serviceAccountEmail` — that name returns HTTP 400 "Cannot bind query
+  # parameter"). It pins the SA the proxy uses for Google Cloud auth (Vertex).
+  [[ -n "$sa" ]] && path="$path&serviceAccount=$sa"
+  local resp code body
+  resp="$(api POST "$path")"
+  code="${resp##*$'\n'}"
+  body="${resp%$'\n'*}"
+  [[ "$code" =~ ^(200|201)$ ]] || die "Deploy failed (HTTP $code): $body"
+}
+
+# ----- phase 5 + 6: bundle deploy -------------------------------------------
+
+deploy_sharedflow() {
+  step "Phase 5 — SharedFlow $SHAREDFLOW_NAME"
+  local zip="$WORK/$SHAREDFLOW_NAME.zip"
+  zip_sharedflow "$SHAREDFLOW_SRC" "$zip"
+  ok "Built bundle ($(wc -c <"$zip") bytes)"
+  local rev
+  rev="$(import_bundle sharedflows "$SHAREDFLOW_NAME" "$zip")"
+  ok "Imported as revision $rev"
+  deploy_revision sharedflows "$SHAREDFLOW_NAME" "$rev"
+  ok "Deployed revision $rev to env=$APIGEE_ENV"
+}
+
+deploy_sync_proxy() {
+  step "Phase 6 — sync proxy $SYNC_PROXY_NAME"
+  local zip="$WORK/$SYNC_PROXY_NAME.zip"
+  zip_proxy "$SYNC_PROXY_SRC" "$zip"
+  ok "Built bundle ($(wc -c <"$zip") bytes)"
+  local rev
+  rev="$(import_bundle apis "$SYNC_PROXY_NAME" "$zip")"
+  ok "Imported as revision $rev"
+  deploy_revision apis "$SYNC_PROXY_NAME" "$rev" "$VERTEX_SA"
+  ok "Deployed revision $rev to env=$APIGEE_ENV with SA=$VERTEX_SA"
+}
+
+# ----- main -----------------------------------------------------------------
+
+echo "AIRS-on-Apigee provisioning"
+echo "  project        = $PROJECT"
+echo "  region         = $REGION"
+echo "  apigee org     = $APIGEE_ORG"
+echo "  apigee env     = $APIGEE_ENV"
+echo "  vertex SA      = $VERTEX_SA"
+echo "  airs profile   = $AIRS_PROFILE"
+echo "  create profile = $CREATE_AIRS_PROFILE"
+[[ -n "$ENVGROUP_HOSTNAME" ]] && echo "  hostname       = $ENVGROUP_HOSTNAME"
+
+enable_apis
+ensure_vertex_sa
+maybe_create_airs_profile
+setup_kvm
+deploy_sharedflow
+deploy_sync_proxy
+
+step "Provisioning complete."
+echo ""
+echo "Deployed in env $APIGEE_ENV:"
+echo "  - SharedFlow $SHAREDFLOW_NAME"
+echo "  - Proxy      $SYNC_PROXY_NAME  basepath=/vertex-airs-sync"
+if [[ -n "$ENVGROUP_HOSTNAME" ]]; then
+  echo ""
+  echo "Smoke test:"
+  echo "  curl -i 'https://$ENVGROUP_HOSTNAME/vertex-airs-sync/v1/projects/$PROJECT/locations/$REGION/publishers/google/models/gemini-2.5-flash:generateContent' \\"
+  echo "    -H 'Content-Type: application/json' \\"
+  echo "    -d '{\"contents\":[{\"role\":\"user\",\"parts\":[{\"text\":\"Hello\"}]}]}'"
+fi

--- a/Google/cloudrun/flow/setup/bootstrap.sh
+++ b/Google/cloudrun/flow/setup/bootstrap.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# bootstrap.sh — ONE-TIME manual setup for the AIRS-on-Apigee pipeline.
+#
+# Run this once, by hand, with an account that has Owner (or equivalent) on
+# the project. It provisions the things the pipeline itself cannot bootstrap:
+#
+#   1. Enables the GCP APIs the pipeline needs
+#   2. Creates the Artifact Registry Docker repo (holds the provisioner image)
+#   3. Creates the Secret Manager secret `airs-api-token`
+#   4. Creates the runtime service account the Cloud Run Job runs as + grants
+#      it the roles it needs to provision everything
+#   5. Grants the Cloud Build service account its roles
+#   6. Prints the command to create the Cloud Build trigger (the GitHub repo
+#      must be connected to Cloud Build in the console first — see notes)
+#
+# Safe to re-run: every step is idempotent.
+
+set -euo pipefail
+
+# ----- args -----------------------------------------------------------------
+
+usage() {
+  cat <<'EOF'
+Usage: bootstrap.sh [options]
+
+Required:
+  --project=PROJECT_ID        GCP project to set up.
+
+Optional:
+  --region=REGION             Default: us-central1
+  --ar-repo=NAME              Artifact Registry repo name. Default: airs-apigee
+  --runtime-sa-name=NAME      Runtime SA account id. Default: airs-pipeline-sa
+  --cloud-build-sa=EMAIL      Cloud Build service account to grant roles to.
+                              Default: the legacy <PROJECT_NUMBER>@cloudbuild
+                              .gserviceaccount.com. If your builds run as the
+                              Compute Engine default SA, pass it explicitly.
+  --airs-token=TOKEN          If given, seeds the airs-api-token secret with
+                              this value. If omitted, an empty secret is
+                              created and you add the value yourself later.
+  -h, --help                  This message.
+EOF
+  exit "${1:-0}"
+}
+
+PROJECT=""
+REGION="us-central1"
+AR_REPO="airs-apigee"
+RUNTIME_SA_NAME="airs-pipeline-sa"
+CLOUD_BUILD_SA=""
+AIRS_TOKEN=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --project=*)          PROJECT="${arg#*=}" ;;
+    --region=*)           REGION="${arg#*=}" ;;
+    --ar-repo=*)          AR_REPO="${arg#*=}" ;;
+    --runtime-sa-name=*)  RUNTIME_SA_NAME="${arg#*=}" ;;
+    --cloud-build-sa=*)   CLOUD_BUILD_SA="${arg#*=}" ;;
+    --airs-token=*)       AIRS_TOKEN="${arg#*=}" ;;
+    -h|--help)            usage 0 ;;
+    *) echo "Unknown argument: $arg" >&2; usage 1 ;;
+  esac
+done
+
+[[ -n "$PROJECT" ]] || { echo "Missing --project" >&2; usage 1; }
+
+# ----- helpers --------------------------------------------------------------
+
+step() { printf "\n\033[1;34m▶ %s\033[0m\n" "$*"; }
+ok()   { printf "  \033[32m✓\033[0m %s\n" "$*"; }
+warn() { printf "  \033[33m!\033[0m %s\n" "$*"; }
+die()  { printf "  \033[31m✗\033[0m %s\n" "$*" >&2; exit 1; }
+
+command -v gcloud >/dev/null || die "gcloud not on PATH"
+
+PROJECT_NUMBER="$(gcloud projects describe "$PROJECT" --format='value(projectNumber)')"
+[[ -n "$PROJECT_NUMBER" ]] || die "Could not resolve project number for $PROJECT"
+
+RUNTIME_SA="${RUNTIME_SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
+[[ -n "$CLOUD_BUILD_SA" ]] || CLOUD_BUILD_SA="${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com"
+
+SECRET_NAME="airs-api-token"
+
+echo "Bootstrapping AIRS-on-Apigee pipeline"
+echo "  project        = $PROJECT ($PROJECT_NUMBER)"
+echo "  region         = $REGION"
+echo "  AR repo        = $AR_REPO"
+echo "  runtime SA     = $RUNTIME_SA"
+echo "  cloud build SA = $CLOUD_BUILD_SA"
+
+# ----- 1: enable APIs -------------------------------------------------------
+
+step "1 — enabling APIs"
+gcloud services enable \
+  cloudbuild.googleapis.com \
+  run.googleapis.com \
+  artifactregistry.googleapis.com \
+  secretmanager.googleapis.com \
+  apigee.googleapis.com \
+  aiplatform.googleapis.com \
+  iam.googleapis.com \
+  cloudresourcemanager.googleapis.com \
+  serviceusage.googleapis.com \
+  --project "$PROJECT" --quiet
+ok "APIs enabled"
+
+# ----- 2: Artifact Registry repo --------------------------------------------
+
+step "2 — Artifact Registry Docker repo '$AR_REPO'"
+if gcloud artifacts repositories describe "$AR_REPO" \
+     --location "$REGION" --project "$PROJECT" >/dev/null 2>&1; then
+  ok "Repo $AR_REPO already exists"
+else
+  gcloud artifacts repositories create "$AR_REPO" \
+    --repository-format=docker \
+    --location "$REGION" \
+    --project "$PROJECT" \
+    --description "AIRS-on-Apigee provisioner images" --quiet
+  ok "Repo $AR_REPO created"
+fi
+
+# ----- 3: Secret Manager secret ---------------------------------------------
+
+step "3 — Secret Manager secret '$SECRET_NAME'"
+if gcloud secrets describe "$SECRET_NAME" --project "$PROJECT" >/dev/null 2>&1; then
+  ok "Secret $SECRET_NAME already exists"
+else
+  gcloud secrets create "$SECRET_NAME" \
+    --replication-policy=automatic --project "$PROJECT" --quiet
+  ok "Secret $SECRET_NAME created"
+fi
+
+if [[ -n "$AIRS_TOKEN" ]]; then
+  printf '%s' "$AIRS_TOKEN" | gcloud secrets versions add "$SECRET_NAME" \
+    --data-file=- --project "$PROJECT" --quiet
+  ok "Secret value added as a new version"
+else
+  warn "No --airs-token given. Add the value before the first pipeline run:"
+  warn "  printf '%s' 'YOUR_AIRS_TOKEN' | gcloud secrets versions add $SECRET_NAME --data-file=- --project $PROJECT"
+fi
+
+# ----- 4: runtime service account + roles -----------------------------------
+
+step "4 — runtime service account '$RUNTIME_SA'"
+if gcloud iam service-accounts describe "$RUNTIME_SA" \
+     --project "$PROJECT" >/dev/null 2>&1; then
+  ok "Runtime SA already exists"
+else
+  gcloud iam service-accounts create "$RUNTIME_SA_NAME" \
+    --project "$PROJECT" \
+    --display-name "AIRS-on-Apigee pipeline provisioner" --quiet
+  ok "Runtime SA created"
+fi
+
+# Roles the Job needs to provision everything. Broad on purpose — this SA
+# enables APIs, creates a service account, edits project IAM, drives Apigee,
+# and reads the AIRS token. Tighten later if your security posture requires.
+RUNTIME_ROLES=(
+  roles/serviceusage.serviceUsageAdmin   # enable APIs
+  roles/iam.serviceAccountAdmin          # create the Vertex SA
+  roles/resourcemanager.projectIamAdmin  # bind roles/aiplatform.user
+  roles/iam.serviceAccountUser           # deploy the proxy "as" the Vertex SA
+  roles/apigee.admin                     # KVM + import + deploy
+  roles/secretmanager.secretAccessor     # read airs-api-token
+)
+for role in "${RUNTIME_ROLES[@]}"; do
+  gcloud projects add-iam-policy-binding "$PROJECT" \
+    --member "serviceAccount:$RUNTIME_SA" \
+    --role "$role" --condition=None --quiet >/dev/null
+  ok "runtime SA → $role"
+done
+
+# ----- 5: Cloud Build service account roles ---------------------------------
+
+step "5 — Cloud Build service account roles"
+CLOUD_BUILD_ROLES=(
+  roles/artifactregistry.writer   # push the provisioner image
+  roles/run.admin                 # deploy + execute the Cloud Run Job
+  roles/iam.serviceAccountUser    # deploy the Job "as" the runtime SA
+  roles/logging.logWriter         # required with logging: CLOUD_LOGGING_ONLY
+)
+
+# Many orgs enforce constraints/cloudbuild.allowedWorkerPools or
+# iam.disableServiceAccountKeyCreation-style policies that FORBID the default
+# Cloud Build / Compute SAs and REQUIRE the trigger to run as a user-managed
+# SA (you'll see "your organization policy requires you to select a
+# user-managed service account"). To work under that policy with no extra
+# identities, we make the runtime SA do double duty: it runs the build AND the
+# Job. So grant the build roles to the runtime SA too. (It already has
+# iam.serviceAccountUser from step 4, letting it deploy the Job "as" itself.)
+for role in "${CLOUD_BUILD_ROLES[@]}"; do
+  gcloud projects add-iam-policy-binding "$PROJECT" \
+    --member "serviceAccount:$RUNTIME_SA" \
+    --role "$role" --condition=None --quiet >/dev/null
+  ok "runtime SA (build identity) → $role"
+done
+
+# Fallback for projects WITHOUT that org policy, where builds run as the legacy
+# cloudbuild SA or the Compute Engine default SA. Harmless to also grant here;
+# the compute SA may not exist yet, which is fine (skipped if so).
+COMPUTE_SA="${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
+for sa in "$CLOUD_BUILD_SA" "$COMPUTE_SA"; do
+  for role in "${CLOUD_BUILD_ROLES[@]}"; do
+    if gcloud projects add-iam-policy-binding "$PROJECT" \
+         --member "serviceAccount:$sa" \
+         --role "$role" --condition=None --quiet >/dev/null 2>&1; then
+      ok "$sa → $role"
+    else
+      warn "$sa → $role (skipped — service account may not exist)"
+    fi
+  done
+done
+
+# ----- 6: Cloud Build trigger (manual — needs a connected repo) -------------
+
+step "6 — Cloud Build trigger"
+warn "The GitHub repo must be connected to Cloud Build BEFORE a trigger can"
+warn "be created. Connecting a repo is a one-time OAuth flow done in the"
+warn "console: Cloud Build → Triggers → Connect Repository."
+echo ""
+warn "TRIGGER REGION: if you connected the repo via the GitHub App ('Install"
+warn "Google Cloud Build'), that is a 1st-gen GLOBAL connection, so the trigger"
+warn "must be created with --region=global. Passing a regional value here makes"
+warn "gcloud look for a 2nd-gen connection that does not exist ('repository not"
+warn "found'). This is separate from _REGION below, which is where the RESOURCES"
+warn "(Artifact Registry, Cloud Run Job) deploy — trigger location != resource"
+warn "location."
+echo ""
+echo "  Once the repo is connected, create the trigger with:"
+echo ""
+echo "    gcloud builds triggers create github \\"
+echo "      --project=$PROJECT \\"
+echo "      --region=global \\"
+echo "      --name=airs-apigee-pipeline \\"
+echo "      --repo-name=YOUR_REPO_NAME \\"
+echo "      --repo-owner=YOUR_GITHUB_USERNAME \\"
+echo "      --branch-pattern='^main$' \\"
+echo "      --build-config=Google/cloudrun/flow/cloudbuild.yaml \\"
+echo "      --service-account=projects/$PROJECT/serviceAccounts/$RUNTIME_SA \\"
+echo "      --substitutions=_REGION=$REGION,_RUNTIME_SA=$RUNTIME_SA,_APIGEE_ORG=$PROJECT,_APIGEE_ENV=eval,_VERTEX_SA=YOUR_VERTEX_SA,_AIRS_PROFILE=YOUR_AIRS_PROFILE,_ENVGROUP_HOSTNAME=YOUR_ENVGROUP_HOSTNAME"
+echo ""
+warn "--service-account is REQUIRED if your org enforces a user-managed-SA"
+warn "policy. Omitting it returns a bare 'INVALID_ARGUMENT' from the API. We"
+warn "reuse the runtime SA ($RUNTIME_SA) as the build identity — step 5 grants"
+warn "it the build roles for exactly this reason."
+echo ""
+warn "_VERTEX_SA: pass any SA email (e.g. vertex-airs-sa@$PROJECT.iam"
+warn ".gserviceaccount.com) — the pipeline CREATES it if missing."
+warn "_AIRS_PROFILE: the security-profile name in your SCM/Strata tenant."
+warn "_ENVGROUP_HOSTNAME: the Apigee env-group hostname (e.g. <IP>.nip.io) —"
+warn "optional, only enables the smoke-test URL in the run summary."
+echo ""
+
+step "Bootstrap complete."
+echo ""
+echo "Next:"
+echo "  1. If you skipped --airs-token, add the secret value (see step 3 above)."
+echo "  2. Connect the GitHub repo and create the trigger (step 6 above)."
+echo "  3. Push to main — the pipeline runs."

--- a/Google/cloudrun/proxy/Dockerfile
+++ b/Google/cloudrun/proxy/Dockerfile
@@ -1,0 +1,20 @@
+# Provisioner image for the monolithic AIRS-on-Apigee proxy Cloud Run Job.
+#
+# Base: Google Cloud SDK (slim) — ships gcloud + bash + curl. We add jq and
+# zip, which provision.sh needs to build the Apigee bundle archive and parse
+# the management-API JSON responses.
+
+FROM google/cloud-sdk:slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends jq zip \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY provision.sh /app/provision.sh
+COPY bundles/ /app/bundles/
+
+RUN chmod +x /app/provision.sh
+
+ENTRYPOINT ["/app/provision.sh"]

--- a/Google/cloudrun/proxy/README.md
+++ b/Google/cloudrun/proxy/README.md
@@ -1,0 +1,87 @@
+# Monolithic AIRS-on-Apigee proxy — Cloud Run pipeline
+
+Automated deployment of the **self-contained `vertex-simple` proxy** — AIRS
+prompt/response scanning **and DLP masking** baked directly into a single Apigee
+API proxy, no SharedFlow. This is the Cloud Run automation of the manual proxy
+published under [`Google/apigee/apiproxy`](../../apigee/apiproxy).
+
+> **Self-contained by design.** This pipeline keeps its **own copy** of the
+> `vertex-simple` bundle under [`bundles/`](bundles/) rather than referencing
+> `Google/apigee/apiproxy/`, so each Cloud Run pipeline is a complete
+> clone-and-run unit (the Docker build context is this folder only). Trade-off:
+> the bundle lives in two places — keep this copy in sync with the canonical
+> one in `Google/apigee/apiproxy/` when that changes.
+
+> Sister pipeline: [`../flow`](../flow) deploys the **reusable
+> SharedFlow** pattern instead. Pick whichever fits — see the [cloudrun README](../README.md).
+
+## When to choose this over the SharedFlow
+
+| | This (monolithic proxy) | SharedFlow |
+|---|---|---|
+| Bundles | one self-contained proxy | a SharedFlow + a thin proxy |
+| DLP masking/redaction | ✅ built in | ✅ (added via the proxy's write-back policies) |
+| Reuse across many proxies / LLMs | ✗ copy per proxy | ✅ edit once, all proxies inherit |
+| Mental model | simplest — one thing to deploy | one extra entity (the flow) |
+
+Choose the monolith when you have a **single LLM proxy** and want the simplest
+possible footprint. Choose the SharedFlow when you front **multiple** proxies/LLMs
+that should share one AIRS posture.
+
+## How it works
+
+```
+client ──POST /vertex──> Apigee (vertex-simple proxy)
+                           │  PreFlow Request:  scan prompt → (mask|block) → call Vertex
+                           │  PostFlow Response: scan response → (mask|block) → return
+                           ▼
+                         Vertex AI :generateContent   (model from KVM, SA-authed)
+```
+
+The pipeline is a **Cloud Build → Cloud Run Job**: Cloud Build builds a
+provisioner image and runs it once as a Job. The Job's `provision.sh` enables
+APIs, ensures the Vertex SA (with the Apigee tokenCreator binding), upserts the
+encrypted `private` KVM, and imports + deploys the proxy.
+
+### The `private` KVM (5 entries)
+
+The monolith reads all config from one env-scoped encrypted KVM named `private`:
+
+| Key | Source | Purpose |
+|---|---|---|
+| `prisma.airs.token` | Secret Manager `airs-api-token` | AIRS scan auth (`x-pan-token`) |
+| `prisma.airs.profile` | `_AIRS_PROFILE` | AIRS security profile |
+| `prisma.airs.host` | `_AIRS_HOST` | AIRS endpoint host, region-bound (proxy prefixes `https://`) |
+| `vertex.project` | the GCP project | Vertex target project |
+| `vertex.model` | `_VERTEX_MODEL` | Vertex model — **baked in**, client doesn't pass it |
+
+## Setup
+
+```bash
+# 1. One-time bootstrap (APIs, AR repo, secret, runtime SA + IAM)
+./setup/bootstrap.sh --project=YOUR_PROJECT_ID --region=us-central1
+
+# 2. Add the AIRS token to Secret Manager (if not passed via --airs-token)
+printf '%s' 'PANW-xxxxxxxx' | gcloud secrets versions add airs-api-token --data-file=- --project YOUR_PROJECT_ID
+
+# 3. Connect the repo to Cloud Build, then create the trigger
+#    (bootstrap.sh prints the exact command — note --build-config=Google/cloudrun/proxy/cloudbuild.yaml)
+```
+
+Then push to `main` — the trigger runs the pipeline. Watch under **Cloud Build →
+History**; the provisioning phases stream under **Cloud Run → Jobs → Logs**.
+
+## Smoke test
+
+Because the model is baked into the KVM, the client just POSTs a prompt to
+`/vertex` (no model in the URL):
+
+```bash
+curl -i 'https://<your-envgroup-hostname>/vertex' \
+  -H 'Content-Type: application/json' \
+  -d '{"contents":[{"role":"user","parts":[{"text":"Hello"}]}]}'
+```
+
+A malicious prompt is blocked by the proxy's `RF-Block` policy; a prompt with
+maskable PII (when the AIRS profile enables masking) is forwarded to Vertex with
+the sensitive spans redacted.

--- a/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/AM-AIRSRequest.xml
+++ b/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/AM-AIRSRequest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<AssignMessage name="AM-AIRSRequest">
+  <Set>
+    <Headers>
+      <Header name="Content-Type">application/json</Header>
+      <Header name="X-Pan-Token">{private.prisma.airs.token}</Header>
+    </Headers>
+    <Payload contentType="application/json">{airs.request.payload}</Payload>
+    <Verb>POST</Verb>
+  </Set>
+  <AssignTo createNew="true" type="request">airs.request</AssignTo>
+</AssignMessage>

--- a/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/AM-AIRSResponseRequest.xml
+++ b/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/AM-AIRSResponseRequest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<AssignMessage name="AM-AIRSResponseRequest">
+  <Set>
+    <Headers>
+      <Header name="Content-Type">application/json</Header>
+      <Header name="X-Pan-Token">{private.prisma.airs.token}</Header>
+    </Headers>
+    <Payload contentType="application/json">{airs.scan.response.payload}</Payload>
+    <Verb>POST</Verb>
+  </Set>
+  <AssignTo createNew="true" type="request">airs.scan.response.request</AssignTo>
+</AssignMessage>

--- a/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/EV-AIRSResponseVerdict.xml
+++ b/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/EV-AIRSResponseVerdict.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ExtractVariables name="EV-AIRSResponseVerdict">
+  <Source>airs.scan.response.result</Source>
+  <JSONPayload>
+    <Variable name="airs.scan.response.action" type="string">
+      <JSONPath>$.action</JSONPath>
+    </Variable>
+    <Variable name="airs.scan.response.category" type="string">
+      <JSONPath>$.category</JSONPath>
+    </Variable>
+    <Variable name="airs.scan.response.redacted" type="string">
+      <JSONPath>$.response_masked_data.data</JSONPath>
+    </Variable>
+  </JSONPayload>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</ExtractVariables>
+

--- a/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/EV-AIRSVerdict.xml
+++ b/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/EV-AIRSVerdict.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ExtractVariables name="EV-AIRSVerdict">
+  <Source>airs.response</Source>
+  <JSONPayload>
+    <Variable name="airs.action" type="string">
+      <JSONPath>$.action</JSONPath>
+    </Variable>
+    <Variable name="airs.category" type="string">
+      <JSONPath>$.category</JSONPath>
+    </Variable>
+    <Variable name="airs.prompt.redacted" type="string">
+      <JSONPath>$.prompt_masked_data.data</JSONPath>
+    </Variable>
+  </JSONPayload>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</ExtractVariables>

--- a/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/JS-ApplyMasking.xml
+++ b/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/JS-ApplyMasking.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Javascript name="JS-ApplyMasking" timeLimit="200">
+  <ResourceURL>jsc://apply-masking.js</ResourceURL>
+</Javascript>
+

--- a/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/JS-ApplyPromptMasking.xml
+++ b/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/JS-ApplyPromptMasking.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Javascript name="JS-ApplyPromptMasking" timeLimit="200">
+  <ResourceURL>jsc://apply-prompt-masking.js</ResourceURL>
+</Javascript>
+
+
+

--- a/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/JS-ScanPrompt.xml
+++ b/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/JS-ScanPrompt.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Javascript name="JS-ScanPrompt" timeLimit="200">
+  <ResourceURL>jsc://scan-prompt.js</ResourceURL>
+</Javascript>

--- a/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/JS-ScanResponse.xml
+++ b/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/JS-ScanResponse.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Javascript name="JS-ScanResponse" timeLimit="200">
+  <ResourceURL>jsc://scan-response.js</ResourceURL>
+</Javascript>
+

--- a/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/KVM-GetConfig.xml
+++ b/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/KVM-GetConfig.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<KeyValueMapOperations name="KVM-GetConfig" mapIdentifier="private">
+  <Scope>environment</Scope>
+  <Get assignTo="private.prisma.airs.token">
+    <Key>
+      <Parameter>prisma.airs.token</Parameter>
+    </Key>
+  </Get>
+  <Get assignTo="private.prisma.airs.profile">
+    <Key>
+      <Parameter>prisma.airs.profile</Parameter>
+    </Key>
+  </Get>
+  <Get assignTo="private.prisma.airs.host">
+    <Key>
+      <Parameter>prisma.airs.host</Parameter>
+    </Key>
+  </Get>
+  <Get assignTo="private.vertex.project">
+    <Key>
+      <Parameter>vertex.project</Parameter>
+    </Key>
+  </Get>
+  <Get assignTo="private.vertex.model">
+    <Key>
+      <Parameter>vertex.model</Parameter>
+    </Key>
+  </Get>
+</KeyValueMapOperations>
+

--- a/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/RF-Block.xml
+++ b/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/RF-Block.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RaiseFault name="RF-Block">
+  <FaultResponse>
+    <Set>
+      <StatusCode>400</StatusCode>
+      <ReasonPhrase>Blocked</ReasonPhrase>
+      <Payload contentType="application/json">{"error":"Prompt blocked by Prisma AIRS","category":"{airs.category}"}</Payload>
+    </Set>
+  </FaultResponse>
+</RaiseFault>

--- a/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/RF-BlockResponse.xml
+++ b/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/RF-BlockResponse.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RaiseFault name="RF-BlockResponse">
+  <FaultResponse>
+    <Set>
+      <StatusCode>400</StatusCode>
+      <ReasonPhrase>Response Blocked</ReasonPhrase>
+      <Payload contentType="application/json">{"error":"Response blocked by Prisma AIRS","category":"{airs.scan.response.category}"}</Payload>
+    </Set>
+  </FaultResponse>
+</RaiseFault>
+

--- a/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/SC-AIRSResponseScan.xml
+++ b/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/SC-AIRSResponseScan.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ServiceCallout name="SC-AIRSResponseScan">
+  <Request variable="airs.scan.response.request"/>
+  <Response>airs.scan.response.result</Response>
+  <Timeout>5000</Timeout>
+  <HTTPTargetConnection>
+    <!-- Literal scheme required (see SC-AIRSScan); host from the KVM. -->
+    <URL>https://{private.prisma.airs.host}/v1/scan/sync/request</URL>
+  </HTTPTargetConnection>
+</ServiceCallout>
+

--- a/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/SC-AIRSScan.xml
+++ b/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/policies/SC-AIRSScan.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ServiceCallout name="SC-AIRSScan">
+  <Request variable="airs.request"/>
+  <Response>airs.response</Response>
+  <Timeout>5000</Timeout>
+  <HTTPTargetConnection>
+    <!-- URL must begin with a literal scheme — Apigee statically validates
+         target URLs at deploy and rejects any starting with a variable
+         (MalformedTargetUrl). The host comes from the KVM so the AIRS region
+         stays configurable. -->
+    <URL>https://{private.prisma.airs.host}/v1/scan/sync/request</URL>
+  </HTTPTargetConnection>
+</ServiceCallout>

--- a/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/proxies/default.xml
+++ b/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/proxies/default.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ProxyEndpoint name="default">
+  <HTTPProxyConnection>
+    <BasePath>/vertex</BasePath>
+  </HTTPProxyConnection>
+  
+  <PreFlow name="PreFlow">
+    <Request>
+      <Step><Name>KVM-GetConfig</Name></Step>
+      <Step><Name>JS-ScanPrompt</Name></Step>
+      <Step><Name>AM-AIRSRequest</Name></Step>
+      <Step><Name>SC-AIRSScan</Name></Step>
+      <Step><Name>EV-AIRSVerdict</Name></Step>
+      <Step>
+        <Name>JS-ApplyPromptMasking</Name>
+        <Condition>(airs.action = "allow") and (airs.prompt.redacted != null)</Condition>
+      </Step>
+      <Step>
+        <Name>RF-Block</Name>
+        <Condition>(airs.action = "block")</Condition>
+      </Step>
+    </Request>
+  </PreFlow>
+  
+  <PostFlow name="PostFlow">
+    <Response>
+      <Step>
+        <Name>JS-ScanResponse</Name>
+        <Condition>(response.status.code >= 200) and (response.status.code &lt; 300)</Condition>
+      </Step>
+      <Step>
+        <Name>AM-AIRSResponseRequest</Name>
+        <Condition>(response.status.code >= 200) and (response.status.code &lt; 300) and (airs.scan.response.payload != null)</Condition>
+      </Step>
+      <Step>
+        <Name>SC-AIRSResponseScan</Name>
+        <Condition>(response.status.code >= 200) and (response.status.code &lt; 300) and (airs.scan.response.payload != null)</Condition>
+      </Step>
+      <Step>
+        <Name>EV-AIRSResponseVerdict</Name>
+        <Condition>(response.status.code >= 200) and (response.status.code &lt; 300) and (airs.scan.response.payload != null)</Condition>
+      </Step>
+      <Step>
+        <Name>JS-ApplyMasking</Name>
+        <Condition>(response.status.code >= 200) and (response.status.code &lt; 300) and (airs.scan.response.action = "allow") and (airs.scan.response.redacted != null)</Condition>
+      </Step>
+      <Step>
+        <Name>RF-BlockResponse</Name>
+        <Condition>(airs.scan.response.action = "block")</Condition>
+      </Step>
+    </Response>
+  </PostFlow>
+  
+  <RouteRule name="default">
+    <TargetEndpoint>vertex-target</TargetEndpoint>
+  </RouteRule>
+</ProxyEndpoint>

--- a/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/resources/jsc/apply-masking.js
+++ b/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/resources/jsc/apply-masking.js
@@ -1,0 +1,39 @@
+// Apply masked content from AIRS when provided
+// AIRS returns masked content in contents[0].response when masking is enabled in the profile
+var action = context.getVariable('airs.scan.response.action');
+var redactedContent = context.getVariable('airs.scan.response.redacted');
+
+// If AIRS provided masked content (regardless of category)
+// This respects the AIRS profile configuration in SCM
+if (action === 'allow' && redactedContent) {
+  try {
+    // Get the original Vertex AI response
+    var originalResponse = context.getVariable('response.content');
+    var responseObj = JSON.parse(originalResponse);
+    
+    // Replace the text with masked content from AIRS
+    if (responseObj.candidates && Array.isArray(responseObj.candidates)) {
+      for (var i = 0; i < responseObj.candidates.length; i++) {
+        if (responseObj.candidates[i].content && 
+            responseObj.candidates[i].content.parts && 
+            Array.isArray(responseObj.candidates[i].content.parts)) {
+          for (var j = 0; j < responseObj.candidates[i].content.parts.length; j++) {
+            if (responseObj.candidates[i].content.parts[j].text) {
+              // Replace with masked content from AIRS
+              responseObj.candidates[i].content.parts[j].text = redactedContent;
+            }
+          }
+        }
+      }
+    }
+    
+    // Set the modified response back
+    context.setVariable('response.content', JSON.stringify(responseObj));
+    context.setVariable('airs.masking.applied', 'true');
+    
+  } catch (e) {
+    // If error, log but don't fail - original response will be returned
+    print('Error applying masking: ' + e);
+  }
+}
+

--- a/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/resources/jsc/apply-prompt-masking.js
+++ b/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/resources/jsc/apply-prompt-masking.js
@@ -1,0 +1,39 @@
+// Apply masked prompt from AIRS before sending to Vertex AI
+// This prevents PII from reaching the LLM when masking is enabled in AIRS profile
+var action = context.getVariable('airs.action');
+var redactedPrompt = context.getVariable('airs.prompt.redacted');
+
+// If AIRS provided masked prompt content (regardless of category)
+// This respects the AIRS profile configuration in SCM
+if (action === 'allow' && redactedPrompt) {
+  try {
+    // Get the original request
+    var originalRequest = context.getVariable('request.content');
+    var requestObj = JSON.parse(originalRequest);
+    
+    // Replace the prompt text with masked content from AIRS
+    if (requestObj.contents && Array.isArray(requestObj.contents)) {
+      for (var i = 0; i < requestObj.contents.length; i++) {
+        if (requestObj.contents[i].parts && Array.isArray(requestObj.contents[i].parts)) {
+          for (var j = 0; j < requestObj.contents[i].parts.length; j++) {
+            if (requestObj.contents[i].parts[j].text) {
+              // Replace with masked prompt from AIRS
+              requestObj.contents[i].parts[j].text = redactedPrompt;
+            }
+          }
+        }
+      }
+    }
+    
+    // Set the modified request that will go to Vertex AI
+    context.setVariable('request.content', JSON.stringify(requestObj));
+    context.setVariable('airs.prompt.masking.applied', 'true');
+    
+  } catch (e) {
+    // If error, log but don't fail - original request will be sent
+    print('Error applying prompt masking: ' + e);
+  }
+}
+
+
+

--- a/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/resources/jsc/scan-prompt.js
+++ b/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/resources/jsc/scan-prompt.js
@@ -1,0 +1,40 @@
+// Extract prompt from Vertex AI request
+var body = context.getVariable('request.content') || '';
+var prompt = '';
+
+try {
+  var obj = JSON.parse(body);
+  if (obj.contents && Array.isArray(obj.contents)) {
+    for (var i = 0; i < obj.contents.length; i++) {
+      var content = obj.contents[i];
+      if (content.parts && Array.isArray(content.parts)) {
+        for (var j = 0; j < content.parts.length; j++) {
+          if (content.parts[j].text) {
+            prompt += content.parts[j].text;
+          }
+        }
+      }
+    }
+  }
+} catch (e) {
+  prompt = body;
+}
+
+// Build AIRS scan payload
+var sessionId = context.getVariable('request.header.X-Session-ID') || context.getVariable('messageid');
+var airsProfile = context.getVariable('request.header.X-Pan-Profile') || context.getVariable('private.prisma.airs.profile') || 'default';
+var vertexModel = context.getVariable('private.vertex.model') || 'gemini-2.5-flash';
+
+var payload = {
+  tr_id: sessionId,
+  ai_profile: {profile_name: airsProfile},
+  metadata: {
+    ai_model: vertexModel,
+    app_user: 'apigee-user',
+    app_name: 'vertex-simple'
+  },
+  contents: [{prompt: prompt}]
+};
+
+context.setVariable('airs.request.payload', JSON.stringify(payload));
+context.setVariable('ai.prompt', prompt);

--- a/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/resources/jsc/scan-response.js
+++ b/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/resources/jsc/scan-response.js
@@ -1,0 +1,39 @@
+// Extract response from Vertex AI (mirrors scan-prompt.js pattern)
+var body = context.getVariable('response.content') || '';
+var response_text = '';
+
+try {
+  var obj = JSON.parse(body);
+  if (obj.candidates && Array.isArray(obj.candidates)) {
+    for (var i = 0; i < obj.candidates.length; i++) {
+      var candidate = obj.candidates[i];
+      if (candidate.content && candidate.content.parts && Array.isArray(candidate.content.parts)) {
+        for (var j = 0; j < candidate.content.parts.length; j++) {
+          if (candidate.content.parts[j].text) {
+            response_text += candidate.content.parts[j].text;
+          }
+        }
+      }
+    }
+  }
+} catch (e) {
+  response_text = body;
+}
+
+// Build AIRS scan payload
+var sessionId = context.getVariable('request.header.X-Session-ID') || context.getVariable('messageid');
+var airsProfile = context.getVariable('request.header.X-Pan-Profile') || context.getVariable('private.prisma.airs.profile') || 'default';
+var vertexModel = context.getVariable('private.vertex.model') || 'gemini-2.5-flash';
+
+var payload = {
+  tr_id: sessionId,
+  ai_profile: {profile_name: airsProfile},
+  metadata: {
+    ai_model: vertexModel,
+    app_user: 'apigee-user',
+    app_name: 'vertex-simple'
+  },
+  contents: [{response: response_text}]
+};
+
+context.setVariable('airs.scan.response.payload', JSON.stringify(payload));

--- a/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/targets/vertex-target.xml
+++ b/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/targets/vertex-target.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<TargetEndpoint name="vertex-target">
+  <HTTPTargetConnection>
+    <URL>https://us-central1-aiplatform.googleapis.com/v1/projects/{private.vertex.project}/locations/us-central1/publishers/google/models/{private.vertex.model}:generateContent</URL>
+    <Authentication>
+      <GoogleAccessToken>
+        <Scopes>
+          <Scope>https://www.googleapis.com/auth/cloud-platform</Scope>
+        </Scopes>
+      </GoogleAccessToken>
+    </Authentication>
+  </HTTPTargetConnection>
+</TargetEndpoint>

--- a/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/vertex-simple.xml
+++ b/Google/cloudrun/proxy/bundles/vertex-simple/apiproxy/vertex-simple.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<APIProxy name="vertex-simple">
+  <Description>Simple Vertex AI proxy</Description>
+</APIProxy>

--- a/Google/cloudrun/proxy/cloudbuild.yaml
+++ b/Google/cloudrun/proxy/cloudbuild.yaml
@@ -1,0 +1,83 @@
+# Cloud Build pipeline — monolithic AIRS-on-Apigee proxy provisioning.
+#
+# Sister pipeline to ../flow. Deploys the self-contained vertex-simple
+# proxy (AIRS scan + DLP masking baked in), no SharedFlow.
+#
+# Fires on every push to the connected branch. Four steps:
+#   1. Build the provisioner Docker image (context = this subfolder via `dir`)
+#   2. Push it to Artifact Registry
+#   3. Create/update the Cloud Run Job with the new image
+#   4. Execute the Job and wait — the build fails if provisioning fails
+#
+# NOTE the `dir: Google/cloudrun/proxy` on the build step: the trigger checks out the
+# whole repo to /workspace and runs from the repo root, so the Docker build
+# context must be pointed at this subfolder.
+
+substitutions:
+  _REGION: us-central1
+  _AR_REPO: airs-apigee-proxy
+  _JOB_NAME: airs-apigee-proxy-provisioner
+  _RUNTIME_SA: ""              # SA the Cloud Run Job runs as (from bootstrap.sh)
+  _APIGEE_ORG: ""              # Apigee org; empty → provision.sh defaults to PROJECT_ID
+  _APIGEE_ENV: eval
+  _VERTEX_SA: ""               # Vertex caller SA email (created if missing)
+  _VERTEX_MODEL: gemini-2.5-flash
+  _AIRS_PROFILE: ""            # AIRS security profile name
+  _AIRS_HOST: "service.api.aisecurity.paloaltonetworks.com"  # AIRS endpoint HOST, region-bound (no scheme)
+  _ENVGROUP_HOSTNAME: ""       # optional — enables smoke-test URL in the summary
+  _CREATE_AIRS_PROFILE: "0"    # "1" opts into AIRS profile creation via mgmt API
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+
+steps:
+  # 1 — build the provisioner image (context = Google/cloudrun/proxy/)
+  - id: build
+    name: gcr.io/cloud-builders/docker
+    dir: Google/cloudrun/proxy
+    args:
+      - build
+      - -t
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/provisioner:$BUILD_ID
+      - -t
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/provisioner:latest
+      - .
+
+  # 2 — push both tags to Artifact Registry
+  - id: push
+    name: gcr.io/cloud-builders/docker
+    args:
+      - push
+      - --all-tags
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/provisioner
+
+  # 3 — create or update the Cloud Run Job with the fresh image
+  - id: deploy-job
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    args:
+      - run
+      - jobs
+      - deploy
+      - ${_JOB_NAME}
+      - --image=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_AR_REPO}/provisioner:latest
+      - --region=${_REGION}
+      - --service-account=${_RUNTIME_SA}
+      - --set-env-vars=PROJECT=$PROJECT_ID,REGION=${_REGION},APIGEE_ORG=${_APIGEE_ORG},APIGEE_ENV=${_APIGEE_ENV},VERTEX_SA=${_VERTEX_SA},VERTEX_MODEL=${_VERTEX_MODEL},AIRS_PROFILE=${_AIRS_PROFILE},AIRS_HOST=${_AIRS_HOST},ENVGROUP_HOSTNAME=${_ENVGROUP_HOSTNAME},CREATE_AIRS_PROFILE=${_CREATE_AIRS_PROFILE}
+      - --set-secrets=AIRS_TOKEN=airs-api-token:latest
+      - --max-retries=0
+      - --task-timeout=900s
+
+  # 4 — run the Job; --wait makes this step (and the build) fail if it fails
+  - id: execute-job
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    args:
+      - run
+      - jobs
+      - execute
+      - ${_JOB_NAME}
+      - --region=${_REGION}
+      - --wait
+
+timeout: 1800s

--- a/Google/cloudrun/proxy/pipeline.env.example
+++ b/Google/cloudrun/proxy/pipeline.env.example
@@ -1,0 +1,58 @@
+# Pipeline configuration reference — MONOLITHIC PROXY.
+#
+# These are the Cloud Build SUBSTITUTION VARIABLES that parameterize the proxy
+# pipeline. They are set on the Cloud Build trigger (see setup/bootstrap.sh
+# step 6), not loaded as a file at runtime. Copy to pipeline.env for your own
+# reference; pipeline.env is gitignored.
+
+# --- Required ---------------------------------------------------------------
+
+# Apigee environment to deploy into.
+_APIGEE_ENV=eval
+
+# Service account email the proxy uses to call Vertex AI.
+# Created automatically by provision.sh if it does not exist.
+_VERTEX_SA=apigee-vertex-sa@YOUR_PROJECT_ID.iam.gserviceaccount.com
+
+# AIRS security profile name the proxy scans against.
+_AIRS_PROFILE=YOUR_AIRS_PROFILE
+
+# Service account the Cloud Run Job runs as (created by bootstrap.sh).
+_RUNTIME_SA=airs-pipeline-sa@YOUR_PROJECT_ID.iam.gserviceaccount.com
+
+# --- Optional (have sensible defaults in cloudbuild.yaml) -------------------
+
+# GCP region for Artifact Registry, Cloud Run, and Vertex. Default: us-central1
+_REGION=us-central1
+
+# Vertex model the proxy targets. The monolith bakes this into the KVM and
+# builds the target URL from it — the client does NOT pass a model. Default:
+# gemini-2.5-flash
+_VERTEX_MODEL=gemini-2.5-flash
+
+# AIRS endpoint HOST (no scheme) — REGION-BOUND, must match the tenant that
+# issued your token. The proxy prefixes a literal https://. Default: US.
+# EU: service-de.api.aisecurity.paloaltonetworks.com
+_AIRS_HOST=service.api.aisecurity.paloaltonetworks.com
+
+# Artifact Registry repo name. Default: airs-apigee-proxy
+_AR_REPO=airs-apigee-proxy
+
+# Cloud Run Job name. Default: airs-apigee-proxy-provisioner
+_JOB_NAME=airs-apigee-proxy-provisioner
+
+# Apigee org. Leave empty to default to the GCP project ID.
+_APIGEE_ORG=
+
+# Env-group hostname. If set, the provisioning summary prints a smoke-test curl.
+_ENVGROUP_HOSTNAME=
+
+# Set to "1" to have provision.sh create the AIRS security profile via the
+# management API. Default "0" — assumes the profile already exists.
+_CREATE_AIRS_PROFILE=0
+
+# --- Secrets (NOT substitution variables) -----------------------------------
+#
+# The AIRS scan token lives in Secret Manager as `airs-api-token` (shared with
+# the flow pipeline) and is injected into the Job by cloudbuild.yaml. Never put
+# it here.

--- a/Google/cloudrun/proxy/provision.sh
+++ b/Google/cloudrun/proxy/provision.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+# provision.sh — full provisioning of the MONOLITHIC AIRS-on-Apigee proxy.
+#
+# Sister to ../flow. That one deploys the reusable PANW-AIRS
+# SharedFlow + a thin proxy. THIS one deploys the self-contained `vertex-simple`
+# proxy (the manual proxy published in PaloAltoNetworks/prisma-airs-integrations
+# under Google/apigee/apiproxy) — AIRS scanning AND DLP masking baked directly
+# into one bundle, no SharedFlow dependency.
+#
+# Runs inside the Cloud Run Job container. All configuration arrives as
+# environment variables (set on the Job by cloudbuild.yaml; secrets injected
+# from Secret Manager). There are no CLI arguments.
+#
+# Phases:
+#   1. Enable required GCP APIs
+#   2. Create / verify the Vertex service account + IAM bindings
+#      (incl. the Apigee-service-agent tokenCreator binding for runtime auth)
+#   3. (guarded) Create / verify the AIRS security profile via the mgmt API
+#   4. Upsert the encrypted Apigee KVM `private` (5 entries the proxy reads)
+#   5. Import + deploy the vertex-simple proxy
+#
+# Every phase is idempotent — safe to re-run on every pipeline trigger.
+
+set -euo pipefail
+
+# ----- config from environment ----------------------------------------------
+
+PROJECT="${PROJECT:-}"
+REGION="${REGION:-us-central1}"
+APIGEE_ORG="${APIGEE_ORG:-$PROJECT}"
+APIGEE_ENV="${APIGEE_ENV:-}"
+VERTEX_SA="${VERTEX_SA:-}"
+AIRS_PROFILE="${AIRS_PROFILE:-}"
+AIRS_TOKEN="${AIRS_TOKEN:-}"
+ENVGROUP_HOSTNAME="${ENVGROUP_HOSTNAME:-}"
+
+# Monolith-specific config (the SharedFlow pipeline doesn't need these):
+#   AIRS_HOST    — AIRS endpoint HOST (no scheme), region-bound. Default: US.
+#                  The proxy prefixes a literal https:// (Apigee rejects target
+#                  URLs that start with a variable), so store host only here.
+#   VERTEX_MODEL — the Vertex model the proxy targets (baked into the KVM;
+#                  the monolith builds the target URL from project + model).
+AIRS_HOST="${AIRS_HOST:-service.api.aisecurity.paloaltonetworks.com}"
+VERTEX_MODEL="${VERTEX_MODEL:-gemini-2.5-flash}"
+
+# Guarded optional: AIRS security-profile creation. Off unless explicitly set.
+CREATE_AIRS_PROFILE="${CREATE_AIRS_PROFILE:-0}"
+AIRS_MGMT_TOKEN="${AIRS_MGMT_TOKEN:-}"
+AIRS_MGMT_API="${AIRS_MGMT_API:-}"
+
+# ----- constants ------------------------------------------------------------
+
+PROXY_NAME="vertex-simple"
+PROXY_SRC="/app/bundles/vertex-simple"
+KVM_NAME="private"          # must match mapIdentifier in KVM-GetConfig.xml
+APIGEE_API="https://apigee.googleapis.com/v1"
+
+REQUIRED_APIS=(
+  apigee.googleapis.com
+  aiplatform.googleapis.com
+  iam.googleapis.com
+  serviceusage.googleapis.com
+)
+
+# ----- output helpers -------------------------------------------------------
+
+step() { printf "\n\033[1;34m▶ %s\033[0m\n" "$*"; }
+ok()   { printf "  \033[32m✓\033[0m %s\n" "$*"; }
+warn() { printf "  \033[33m!\033[0m %s\n" "$*"; }
+die()  { printf "  \033[31m✗\033[0m %s\n" "$*" >&2; exit 1; }
+
+# ----- validation -----------------------------------------------------------
+
+[[ -n "$PROJECT"      ]] || die "PROJECT not set"
+[[ -n "$APIGEE_ENV"   ]] || die "APIGEE_ENV not set"
+[[ -n "$VERTEX_SA"    ]] || die "VERTEX_SA not set"
+[[ -n "$AIRS_PROFILE" ]] || die "AIRS_PROFILE not set"
+[[ -n "$AIRS_TOKEN"   ]] || die "AIRS_TOKEN not set (expected from Secret Manager)"
+
+command -v gcloud >/dev/null || die "gcloud not on PATH"
+command -v jq     >/dev/null || die "jq not on PATH"
+command -v zip    >/dev/null || die "zip not on PATH"
+command -v curl   >/dev/null || die "curl not on PATH"
+
+[[ -d "$PROXY_SRC" ]] || die "Missing bundle dir $PROXY_SRC"
+
+gcloud config set project "$PROJECT" --quiet >/dev/null 2>&1
+TOKEN="$(gcloud auth print-access-token)"
+[[ -n "$TOKEN" ]] || die "gcloud auth print-access-token returned empty"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ----- Apigee mgmt API helpers ----------------------------------------------
+
+api() {
+  local method="$1" path="$2" body="${3:-}"
+  local extra_args=("-sS" "-X" "$method" "-H" "Authorization: Bearer $TOKEN")
+  if [[ -n "$body" ]]; then
+    extra_args+=("-H" "Content-Type: application/json" "--data" "$body")
+  fi
+  extra_args+=("-w" "\n%{http_code}")
+  curl "${extra_args[@]}" "$APIGEE_API$path"
+}
+
+api_status() {
+  curl -sS -o /dev/null -w "%{http_code}" \
+    -H "Authorization: Bearer $TOKEN" "$APIGEE_API$1"
+}
+
+# ----- phase 1: enable APIs -------------------------------------------------
+
+enable_apis() {
+  step "Phase 1 — enabling required GCP APIs"
+  gcloud services enable "${REQUIRED_APIS[@]}" --project "$PROJECT" --quiet
+  for a in "${REQUIRED_APIS[@]}"; do ok "$a"; done
+}
+
+# ----- phase 2: Vertex service account --------------------------------------
+
+ensure_vertex_sa() {
+  step "Phase 2 — Vertex service account"
+
+  local sa_id="${VERTEX_SA%%@*}"
+
+  if gcloud iam service-accounts describe "$VERTEX_SA" \
+       --project "$PROJECT" >/dev/null 2>&1; then
+    ok "Service account $VERTEX_SA exists"
+  else
+    gcloud iam service-accounts create "$sa_id" \
+      --project "$PROJECT" \
+      --display-name "Apigee → Vertex AI caller (AIRS monolith)" --quiet
+    ok "Service account $VERTEX_SA created"
+  fi
+
+  gcloud projects add-iam-policy-binding "$PROJECT" \
+    --member "serviceAccount:$VERTEX_SA" \
+    --role "roles/aiplatform.user" \
+    --condition=None --quiet >/dev/null
+  ok "roles/aiplatform.user bound to $VERTEX_SA"
+
+  # At RUNTIME the Apigee data plane impersonates this SA to mint the Google
+  # access token for the Vertex target (<Authentication><GoogleAccessToken>).
+  # Without the Token Creator binding the proxy returns HTTP 500
+  # GoogleTokenGenerationFailure even though deployment succeeds.
+  local proj_num apigee_agent
+  proj_num="$(gcloud projects describe "$PROJECT" --format='value(projectNumber)')"
+  apigee_agent="service-${proj_num}@gcp-sa-apigee.iam.gserviceaccount.com"
+  gcloud iam service-accounts add-iam-policy-binding "$VERTEX_SA" \
+    --member "serviceAccount:$apigee_agent" \
+    --role "roles/iam.serviceAccountTokenCreator" \
+    --project "$PROJECT" --quiet >/dev/null
+  ok "roles/iam.serviceAccountTokenCreator: $apigee_agent → $VERTEX_SA"
+}
+
+# ----- phase 3: AIRS security profile (guarded optional) --------------------
+
+maybe_create_airs_profile() {
+  step "Phase 3 — AIRS security profile"
+
+  if [[ "$CREATE_AIRS_PROFILE" != "1" ]]; then
+    ok "CREATE_AIRS_PROFILE not set — assuming profile '$AIRS_PROFILE' already exists"
+    return 0
+  fi
+
+  [[ -n "$AIRS_MGMT_API"   ]] || die "CREATE_AIRS_PROFILE=1 but AIRS_MGMT_API not set"
+  [[ -n "$AIRS_MGMT_TOKEN" ]] || die "CREATE_AIRS_PROFILE=1 but AIRS_MGMT_TOKEN not set"
+
+  local resp code body
+  resp="$(curl -sS -X POST \
+    -H "Authorization: Bearer $AIRS_MGMT_TOKEN" \
+    -H "Content-Type: application/json" \
+    -w "\n%{http_code}" \
+    --data "$(jq -n --arg n "$AIRS_PROFILE" '{name:$n}')" \
+    "$AIRS_MGMT_API/v1/ai-security-profiles")"
+  code="${resp##*$'\n'}"
+  body="${resp%$'\n'*}"
+
+  if [[ "$code" =~ ^(200|201)$ ]]; then
+    ok "AIRS security profile '$AIRS_PROFILE' created"
+  elif [[ "$code" == "409" ]]; then
+    ok "AIRS security profile '$AIRS_PROFILE' already exists"
+  else
+    die "AIRS profile create failed (HTTP $code): $body"
+  fi
+}
+
+# ----- phase 4: KVM ---------------------------------------------------------
+
+setup_kvm() {
+  step "Phase 4 — encrypted KVM $KVM_NAME in env=$APIGEE_ENV"
+
+  local kvm_path="/organizations/$APIGEE_ORG/environments/$APIGEE_ENV/keyvaluemaps/$KVM_NAME"
+  local status
+  status="$(api_status "$kvm_path")"
+
+  if [[ "$status" == "200" ]]; then
+    ok "KVM $KVM_NAME exists"
+  else
+    local body code
+    body="$(api POST "/organizations/$APIGEE_ORG/environments/$APIGEE_ENV/keyvaluemaps" \
+              "$(jq -n --arg n "$KVM_NAME" '{name:$n, encrypted:true}')")"
+    code="${body##*$'\n'}"
+    [[ "$code" =~ ^(200|201)$ ]] || die "KVM create failed (HTTP $code): $body"
+    ok "KVM $KVM_NAME created (encrypted)"
+  fi
+
+  # The vertex-simple proxy's KVM-GetConfig reads exactly these five keys.
+  upsert_kvm_entry "$kvm_path" "prisma.airs.token"   "$AIRS_TOKEN"
+  upsert_kvm_entry "$kvm_path" "prisma.airs.profile" "$AIRS_PROFILE"
+  upsert_kvm_entry "$kvm_path" "prisma.airs.host"    "$AIRS_HOST"
+  upsert_kvm_entry "$kvm_path" "vertex.project"      "$PROJECT"
+  upsert_kvm_entry "$kvm_path" "vertex.model"        "$VERTEX_MODEL"
+}
+
+upsert_kvm_entry() {
+  local kvm_path="$1" key="$2" val="$3"
+  local entry_path="$kvm_path/entries/$key"
+  local entry_status payload resp code
+  entry_status="$(api_status "$entry_path")"
+  payload="$(jq -n --arg n "$key" --arg v "$val" '{name:$n, value:$v}')"
+
+  if [[ "$entry_status" == "200" ]]; then
+    resp="$(api PUT "$entry_path" "$payload")"
+    code="${resp##*$'\n'}"
+    [[ "$code" =~ ^(200|201)$ ]] || die "KVM entry update $key failed (HTTP $code): $resp"
+    ok "KVM entry $key updated"
+  else
+    resp="$(api POST "$kvm_path/entries" "$payload")"
+    code="${resp##*$'\n'}"
+    [[ "$code" =~ ^(200|201)$ ]] || die "KVM entry create $key failed (HTTP $code): $resp"
+    ok "KVM entry $key created"
+  fi
+}
+
+# ----- bundle helpers -------------------------------------------------------
+
+zip_proxy() { ( cd "$1" && zip -qr "$2" apiproxy -x "*.DS_Store" ); }
+
+import_bundle() {
+  local name="$1" zip="$2"
+  local resp code body rev
+  resp="$(curl -sS -X POST \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: multipart/form-data" \
+    -F "file=@$zip" \
+    -w "\n%{http_code}" \
+    "$APIGEE_API/organizations/$APIGEE_ORG/apis?action=import&name=$name")"
+  code="${resp##*$'\n'}"
+  body="${resp%$'\n'*}"
+  [[ "$code" =~ ^(200|201)$ ]] || die "Bundle import failed (HTTP $code): $body"
+  rev="$(echo "$body" | jq -r '.revision // empty')"
+  [[ -n "$rev" ]] || die "No revision returned in import response: $body"
+  echo "$rev"
+}
+
+deploy_revision() {
+  local name="$1" rev="$2" sa="$3"
+  # Apigee deployments API query param is `serviceAccount` (NOT
+  # `serviceAccountEmail`, which returns HTTP 400 "Cannot bind query parameter").
+  local path="/organizations/$APIGEE_ORG/environments/$APIGEE_ENV/apis/$name/revisions/$rev/deployments?override=true&serviceAccount=$sa"
+  local resp code body
+  resp="$(api POST "$path")"
+  code="${resp##*$'\n'}"
+  body="${resp%$'\n'*}"
+  [[ "$code" =~ ^(200|201)$ ]] || die "Deploy failed (HTTP $code): $body"
+}
+
+# ----- phase 5: proxy deploy ------------------------------------------------
+
+deploy_proxy() {
+  step "Phase 5 — proxy $PROXY_NAME"
+  local zip="$WORK/$PROXY_NAME.zip"
+  zip_proxy "$PROXY_SRC" "$zip"
+  ok "Built bundle ($(wc -c <"$zip") bytes)"
+  local rev
+  rev="$(import_bundle "$PROXY_NAME" "$zip")"
+  ok "Imported as revision $rev"
+  deploy_revision "$PROXY_NAME" "$rev" "$VERTEX_SA"
+  ok "Deployed revision $rev to env=$APIGEE_ENV with SA=$VERTEX_SA"
+}
+
+# ----- main -----------------------------------------------------------------
+
+echo "AIRS-on-Apigee provisioning (MONOLITHIC PROXY)"
+echo "  project        = $PROJECT"
+echo "  region         = $REGION"
+echo "  apigee org     = $APIGEE_ORG"
+echo "  apigee env     = $APIGEE_ENV"
+echo "  vertex SA      = $VERTEX_SA"
+echo "  vertex model   = $VERTEX_MODEL"
+echo "  airs profile   = $AIRS_PROFILE"
+echo "  airs host      = $AIRS_HOST"
+echo "  create profile = $CREATE_AIRS_PROFILE"
+[[ -n "$ENVGROUP_HOSTNAME" ]] && echo "  hostname       = $ENVGROUP_HOSTNAME"
+
+enable_apis
+ensure_vertex_sa
+maybe_create_airs_profile
+setup_kvm
+deploy_proxy
+
+step "Provisioning complete."
+echo ""
+echo "Deployed in env $APIGEE_ENV:"
+echo "  - Proxy $PROXY_NAME  basepath=/vertex  (model baked from KVM: $VERTEX_MODEL)"
+if [[ -n "$ENVGROUP_HOSTNAME" ]]; then
+  echo ""
+  echo "Smoke test (model comes from the KVM, so the client just POSTs a prompt):"
+  echo "  curl -i 'https://$ENVGROUP_HOSTNAME/vertex' \\"
+  echo "    -H 'Content-Type: application/json' \\"
+  echo "    -d '{\"contents\":[{\"role\":\"user\",\"parts\":[{\"text\":\"Hello\"}]}]}'"
+fi

--- a/Google/cloudrun/proxy/setup/bootstrap.sh
+++ b/Google/cloudrun/proxy/setup/bootstrap.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# bootstrap.sh — ONE-TIME manual setup for the MONOLITHIC PROXY pipeline.
+#
+# Sister to ../flow/setup/bootstrap.sh. Run once, by hand, with an
+# account that has Owner (or equivalent) on the project. It provisions what the
+# pipeline itself cannot bootstrap:
+#
+#   1. Enables the GCP APIs the pipeline needs
+#   2. Creates the Artifact Registry Docker repo (proxy provisioner image)
+#   3. Creates the Secret Manager secret `airs-api-token` (SHARED with the flow
+#      pipeline — idempotent if you already created it there)
+#   4. Creates/reuses the runtime service account + grants provisioning roles
+#   5. Grants Cloud Build roles (incl. to the runtime SA, used as the build
+#      identity under a user-managed-SA org policy)
+#   6. Prints the command to create the Cloud Build trigger
+#
+# Safe to re-run: every step is idempotent.
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: bootstrap.sh [options]
+
+Required:
+  --project=PROJECT_ID        GCP project to set up.
+
+Optional:
+  --region=REGION             Default: us-central1
+  --ar-repo=NAME              Artifact Registry repo. Default: airs-apigee-proxy
+  --runtime-sa-name=NAME      Runtime SA account id. Default: airs-pipeline-sa
+  --cloud-build-sa=EMAIL      Cloud Build SA to grant roles to. Default: the
+                              legacy <PROJECT_NUMBER>@cloudbuild SA.
+  --airs-token=TOKEN          Seeds the airs-api-token secret. If omitted, an
+                              empty secret is created and you add the value.
+  -h, --help                  This message.
+EOF
+  exit "${1:-0}"
+}
+
+PROJECT=""
+REGION="us-central1"
+AR_REPO="airs-apigee-proxy"
+RUNTIME_SA_NAME="airs-pipeline-sa"
+CLOUD_BUILD_SA=""
+AIRS_TOKEN=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --project=*)          PROJECT="${arg#*=}" ;;
+    --region=*)           REGION="${arg#*=}" ;;
+    --ar-repo=*)          AR_REPO="${arg#*=}" ;;
+    --runtime-sa-name=*)  RUNTIME_SA_NAME="${arg#*=}" ;;
+    --cloud-build-sa=*)   CLOUD_BUILD_SA="${arg#*=}" ;;
+    --airs-token=*)       AIRS_TOKEN="${arg#*=}" ;;
+    -h|--help)            usage 0 ;;
+    *) echo "Unknown argument: $arg" >&2; usage 1 ;;
+  esac
+done
+
+[[ -n "$PROJECT" ]] || { echo "Missing --project" >&2; usage 1; }
+
+step() { printf "\n\033[1;34m▶ %s\033[0m\n" "$*"; }
+ok()   { printf "  \033[32m✓\033[0m %s\n" "$*"; }
+warn() { printf "  \033[33m!\033[0m %s\n" "$*"; }
+die()  { printf "  \033[31m✗\033[0m %s\n" "$*" >&2; exit 1; }
+
+command -v gcloud >/dev/null || die "gcloud not on PATH"
+
+PROJECT_NUMBER="$(gcloud projects describe "$PROJECT" --format='value(projectNumber)')"
+[[ -n "$PROJECT_NUMBER" ]] || die "Could not resolve project number for $PROJECT"
+
+RUNTIME_SA="${RUNTIME_SA_NAME}@${PROJECT}.iam.gserviceaccount.com"
+[[ -n "$CLOUD_BUILD_SA" ]] || CLOUD_BUILD_SA="${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com"
+SECRET_NAME="airs-api-token"
+
+echo "Bootstrapping AIRS-on-Apigee MONOLITHIC PROXY pipeline"
+echo "  project        = $PROJECT ($PROJECT_NUMBER)"
+echo "  region         = $REGION"
+echo "  AR repo        = $AR_REPO"
+echo "  runtime SA     = $RUNTIME_SA"
+echo "  cloud build SA = $CLOUD_BUILD_SA"
+
+# ----- 1: enable APIs -------------------------------------------------------
+
+step "1 — enabling APIs"
+gcloud services enable \
+  cloudbuild.googleapis.com run.googleapis.com artifactregistry.googleapis.com \
+  secretmanager.googleapis.com apigee.googleapis.com aiplatform.googleapis.com \
+  iam.googleapis.com cloudresourcemanager.googleapis.com serviceusage.googleapis.com \
+  --project "$PROJECT" --quiet
+ok "APIs enabled"
+
+# ----- 2: Artifact Registry repo --------------------------------------------
+
+step "2 — Artifact Registry Docker repo '$AR_REPO'"
+if gcloud artifacts repositories describe "$AR_REPO" \
+     --location "$REGION" --project "$PROJECT" >/dev/null 2>&1; then
+  ok "Repo $AR_REPO already exists"
+else
+  gcloud artifacts repositories create "$AR_REPO" \
+    --repository-format=docker --location "$REGION" --project "$PROJECT" \
+    --description "AIRS-on-Apigee monolithic proxy provisioner images" --quiet
+  ok "Repo $AR_REPO created"
+fi
+
+# ----- 3: Secret Manager secret (shared with the flow pipeline) -------------
+
+step "3 — Secret Manager secret '$SECRET_NAME'"
+if gcloud secrets describe "$SECRET_NAME" --project "$PROJECT" >/dev/null 2>&1; then
+  ok "Secret $SECRET_NAME already exists (shared with flow pipeline)"
+else
+  gcloud secrets create "$SECRET_NAME" \
+    --replication-policy=automatic --project "$PROJECT" --quiet
+  ok "Secret $SECRET_NAME created"
+fi
+
+if [[ -n "$AIRS_TOKEN" ]]; then
+  printf '%s' "$AIRS_TOKEN" | gcloud secrets versions add "$SECRET_NAME" \
+    --data-file=- --project "$PROJECT" --quiet
+  ok "Secret value added as a new version"
+else
+  warn "No --airs-token given. Add the value before the first pipeline run:"
+  warn "  printf '%s' 'YOUR_AIRS_TOKEN' | gcloud secrets versions add $SECRET_NAME --data-file=- --project $PROJECT"
+fi
+
+# ----- 4: runtime service account + roles -----------------------------------
+
+step "4 — runtime service account '$RUNTIME_SA'"
+if gcloud iam service-accounts describe "$RUNTIME_SA" \
+     --project "$PROJECT" >/dev/null 2>&1; then
+  ok "Runtime SA already exists (shared with flow pipeline)"
+else
+  gcloud iam service-accounts create "$RUNTIME_SA_NAME" \
+    --project "$PROJECT" \
+    --display-name "AIRS-on-Apigee pipeline provisioner" --quiet
+  ok "Runtime SA created"
+fi
+
+RUNTIME_ROLES=(
+  roles/serviceusage.serviceUsageAdmin   # enable APIs
+  roles/iam.serviceAccountAdmin          # create the Vertex SA
+  roles/resourcemanager.projectIamAdmin  # bind aiplatform.user + tokenCreator
+  roles/iam.serviceAccountUser           # deploy the proxy "as" the Vertex SA
+  roles/apigee.admin                     # KVM + import + deploy
+  roles/secretmanager.secretAccessor     # read airs-api-token
+)
+for role in "${RUNTIME_ROLES[@]}"; do
+  gcloud projects add-iam-policy-binding "$PROJECT" \
+    --member "serviceAccount:$RUNTIME_SA" --role "$role" \
+    --condition=None --quiet >/dev/null
+  ok "runtime SA → $role"
+done
+
+# ----- 5: Cloud Build service account roles ---------------------------------
+
+step "5 — Cloud Build service account roles"
+CLOUD_BUILD_ROLES=(
+  roles/artifactregistry.writer
+  roles/run.admin
+  roles/iam.serviceAccountUser
+  roles/logging.logWriter
+)
+
+# Org policy may REQUIRE a user-managed build SA — reuse the runtime SA as the
+# build identity (see ../flow bootstrap for the full rationale).
+for role in "${CLOUD_BUILD_ROLES[@]}"; do
+  gcloud projects add-iam-policy-binding "$PROJECT" \
+    --member "serviceAccount:$RUNTIME_SA" --role "$role" \
+    --condition=None --quiet >/dev/null
+  ok "runtime SA (build identity) → $role"
+done
+
+# Fallback for projects without that org policy (default cloudbuild/compute SA).
+COMPUTE_SA="${PROJECT_NUMBER}-compute@developer.gserviceaccount.com"
+for sa in "$CLOUD_BUILD_SA" "$COMPUTE_SA"; do
+  for role in "${CLOUD_BUILD_ROLES[@]}"; do
+    if gcloud projects add-iam-policy-binding "$PROJECT" \
+         --member "serviceAccount:$sa" --role "$role" \
+         --condition=None --quiet >/dev/null 2>&1; then
+      ok "$sa → $role"
+    else
+      warn "$sa → $role (skipped — service account may not exist)"
+    fi
+  done
+done
+
+# ----- 6: Cloud Build trigger -----------------------------------------------
+
+step "6 — Cloud Build trigger"
+warn "Connect the GitHub repo to Cloud Build first (console one-time OAuth):"
+warn "  Cloud Build → Triggers → Connect Repository."
+echo ""
+warn "TRIGGER REGION: GitHub App connections are 1st-gen GLOBAL, so use"
+warn "--region=global. --service-account is required under a user-managed-SA"
+warn "org policy (omitting it returns a bare INVALID_ARGUMENT)."
+echo ""
+echo "  Once connected, create the trigger with:"
+echo ""
+echo "    gcloud builds triggers create github \\"
+echo "      --project=$PROJECT \\"
+echo "      --region=global \\"
+echo "      --name=airs-apigee-proxy-pipeline \\"
+echo "      --repo-name=YOUR_REPO_NAME \\"
+echo "      --repo-owner=YOUR_GITHUB_USERNAME \\"
+echo "      --branch-pattern='^main$' \\"
+echo "      --build-config=Google/cloudrun/proxy/cloudbuild.yaml \\"
+echo "      --service-account=projects/$PROJECT/serviceAccounts/$RUNTIME_SA \\"
+echo "      --substitutions=_REGION=$REGION,_RUNTIME_SA=$RUNTIME_SA,_APIGEE_ORG=$PROJECT,_APIGEE_ENV=eval,_VERTEX_SA=YOUR_VERTEX_SA,_VERTEX_MODEL=gemini-2.5-flash,_AIRS_PROFILE=YOUR_AIRS_PROFILE,_ENVGROUP_HOSTNAME=YOUR_ENVGROUP_HOSTNAME"
+echo ""
+warn "--build-config points at Google/cloudrun/proxy/cloudbuild.yaml (the proxy lives"
+warn "in a subfolder). The flow pipeline uses Google/cloudrun/flow/cloudbuild.yaml."
+echo ""
+
+step "Bootstrap complete."
+echo ""
+echo "Next:"
+echo "  1. If you skipped --airs-token, add the secret value (see step 3)."
+echo "  2. Connect the GitHub repo and create the trigger (step 6)."
+echo "  3. Push to main — the pipeline runs."


### PR DESCRIPTION
## Description

Adds `Google/cloudrun/` — git-push-driven **Cloud Build → Cloud Run Job** automation that provisions the AIRS + Vertex AI on Apigee X reference patterns end to end (enable APIs, create the Vertex service account + IAM bindings, configure the encrypted KVM, import + deploy the Apigee bundles), with no manual `gcloud`/`curl` steps. Placement under `Google/cloudrun/` (sibling to `Google/apigee/`) discussed and agreed with the maintainer.

Two self-contained pipelines:

- **`cloudrun/flow/`** — the SharedFlow pattern (`PANW-AIRS` + thin `vertex-airs-sync` proxy), including DLP-masking write-back in the proxy.
- **`cloudrun/proxy/`** — the monolithic `vertex-simple` proxy (AIRS scan + DLP masking baked in).

Each is a complete `bootstrap.sh` → Cloud Build trigger → `git push` flow.

## Self-contained by design

Each pipeline carries its **own copy** of the Apigee bundles under its `bundles/` folder rather than referencing `../apigee`:

- `cloudrun/flow/bundles/` ↔ `apigee/sharedflow/`
- `cloudrun/proxy/bundles/vertex-simple/` ↔ `apigee/apiproxy/`

This keeps each pipeline a clone-and-run unit and lets the Docker build context be the pipeline folder only. The trade-off (bundles in two places) is documented in each README with a "keep in sync" note. Open to switching to a referenced/shared layout if you'd prefer that — flagged here as an explicit design choice.

## Note on bundle divergence

The bundled copies include the deploy fixes required to actually run on Apigee X, which are also proposed for the canonical bundles:

- the `serviceAccount` (not `serviceAccountEmail`) deployments param — see #42,
- the `vertex-simple` ServiceCallout target URL beginning with a literal scheme (`https://{host}/...`) instead of a leading variable, which otherwise fails deploy with `MalformedTargetUrl` (a fix for the canonical `apigee/apiproxy/` will follow),
- and the Apigee-service-agent `tokenCreator` binding (handled in `provision.sh`).

Intent is for the copies and the canonical bundles to converge as those land.

## How Has This Been Tested?

Both pipelines verified end-to-end against a live Apigee X evaluation org fronting Vertex AI (`gemini-2.5-flash`):

- `flow/` → Cloud Build green, SharedFlow + proxy deployed; benign prompt `200`, prompt-injection returns the `200` graceful-block envelope (`airs.action=block`).
- `proxy/` → Cloud Build green, `vertex-simple` deployed READY; benign `200`, injection blocked by `RF-Block`.
- Scoped triggers (`--included-files`) confirmed: a push under `flow/` builds only the flow pipeline, and vice versa.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] No real credentials in the diff (placeholders / KVM + Secret Manager refs only).
- [x] Conventional commit messages.
- [x] Tested end-to-end in a clean GCP project.
- [x] READMEs include setup, validation, and the self-contained design note.
