### PR TITLE
feat(kong/v2): claim-based AIRS profile selection from a signed JWT claim

### DIFF
--- a/Kong/custom-plugin-v2/README.md
+++ b/Kong/custom-plugin-v2/README.md
@@ -39,7 +39,10 @@ v2 extends [v1](../custom-plugin/) with MCP JSON-RPC inspection: `tools/call` re
 | Parameter | Required | Default | Description |
 |-----------|:--------:|---------|-------------|
 | `api_key` | Yes | - | Prisma AIRS API token |
-| `profile_name` | Yes | - | AIRS security profile name |
+| `profile_name` | Yes | - | AIRS security profile name (static default; see [Dynamic profile selection](#dynamic-profile-selection-claim-based)) |
+| `profile_claim` | No | - | JWT claim that selects the profile per request (e.g. `risk_tier`). Unset = static `profile_name`. |
+| `profile_claim_map` | No | - | Map of claim value to profile name. Omit to use the claim value directly as the profile name. |
+| `fallback_profile_name` | No | `profile_name` | Strict profile applied when the claim is missing or unmapped (fail closed). |
 | `app_name` | No | - | Application identifier (sent as `kong-{app_name}`; also used as MCP `server_name`) |
 | `api_endpoint` | No | `https://service.api.aisecurity.paloaltonetworks.com/v1/scan/sync/request` | AIRS API endpoint |
 | `ssl_verify` | No | `true` | Verify SSL certificates. **Keep `true` on Kong 3.14+** — global `tls_certificate_verify` enforcement rejects a per-plugin `ssl_verify=false`. |
@@ -50,6 +53,49 @@ v2 extends [v1](../custom-plugin/) with MCP JSON-RPC inspection: `tools/call` re
 | `sse_max_scan_chars` | No | `20000` | Max reconstructed chars sent to AIRS before the over-limit policy applies. The `20000` default mirrors the conservative response/tool-output scan cap used by other AIRS reference integrations; the `sse_max_scan_chars` field itself is specific to this Kong v2 plugin (see Notes). Over-limit behavior is governed by `sse_truncation_fail_closed`. |
 | `sse_set_observability_headers` | No | `false` | When `true`, add `x-prisma-airs-sse-detected`, `-scan-mode: buffered`, `-provider`, and `-truncated` response headers. |
 | `sse_truncation_fail_closed` | No | `true` | **Secure default.** When `true`, a reconstructed response exceeding `sse_max_scan_chars` cannot be fully scanned, so it is **blocked (403)** rather than returned. Set to `false` to opt into fail-open (scan only the first `sse_max_scan_chars` and return the full response anyway), accepting that content past the cap is returned unscanned. |
+
+## Dynamic profile selection (claim-based)
+
+Apply a different AIRS profile per request on a **single shared route**, chosen
+from a signed JWT claim, instead of a gateway (or route) per app. The profile is
+selected from the caller's already-validated token, so it cannot be spoofed the
+way a header can.
+
+**Requires an auth plugin in front.** This plugin runs at priority `1000`, below
+`jwt` (1450) and `openid-connect` (1050), so the token is validated before the
+claim is read. On a route with no auth plugin, no valid claim is present and
+selection falls **closed** to `fallback_profile_name`. Do not enable claim-based
+selection on an unauthenticated route.
+
+Example — one shared route, profile chosen by a `risk_tier` claim:
+
+```json
+{
+  "name": "prisma-airs-intercept",
+  "config": {
+    "api_key": "YOUR_AIRS_API_KEY",
+    "profile_name": "default-baseline",
+    "profile_claim": "risk_tier",
+    "profile_claim_map": {
+      "high": "strict-production",
+      "medium": "default-baseline",
+      "low": "flexible-internal"
+    },
+    "fallback_profile_name": "strict-production"
+  }
+}
+```
+
+Resolution: claim value to mapped profile; a missing or unmapped claim falls
+closed to `fallback_profile_name`; with no `profile_claim` set, behavior is the
+legacy static `profile_name`. The resolved profile is logged (with `debug`) and
+stamped on the upstream request as `X-AIRS-Profile-Used`.
+
+Unit tests (pure resolver helpers, no Kong runtime needed):
+
+```bash
+lua spec/profile_selection_spec.lua
+```
 
 ## Installation
 

--- a/Kong/custom-plugin-v2/handler.lua
+++ b/Kong/custom-plugin-v2/handler.lua
@@ -25,6 +25,80 @@ local function log_debug(config, msg)
 end
 
 -- ============================================================================
+-- Dynamic AIRS profile selection from a signed JWT claim
+--   Choose the AIRS security profile per request from a claim in the caller's
+--   ALREADY-VALIDATED bearer token, so one shared gateway applies app-specific
+--   guardrails without a gateway per app. This plugin runs at PRIORITY 1000,
+--   i.e. AFTER kong `jwt` (1450) and `openid-connect` (1050), so the signature
+--   is verified before we decode the payload. A signed claim is unspoofable
+--   where a header (X-Prisma-Profile) is not. If no auth plugin precedes us,
+--   no valid claim is present and selection falls CLOSED to fallback_profile_name.
+--   Pure helpers are exposed on `._profile` for tests.
+-- ============================================================================
+
+-- base64url -> bytes (JWT segments are base64url, unpadded).
+local function b64url_decode(input)
+    if not input then return nil end
+    input = input:gsub("-", "+"):gsub("_", "/")
+    local rem = #input % 4
+    if rem == 2 then input = input .. "=="
+    elseif rem == 3 then input = input .. "="
+    elseif rem == 1 then return nil end
+    return ngx.decode_base64(input)
+end
+
+-- Pure: read one claim from a bearer token's payload. Does NOT verify the
+-- signature (the upstream auth plugin already did); only decodes the payload.
+local function get_claim(auth_header, claim_name)
+    if not auth_header or not claim_name then return nil end
+    local token = auth_header:match("^[Bb]earer%s+(.+)$") or auth_header
+    local payload_b64 = token:match("^[^%.]+%.([^%.]+)%.")
+    if not payload_b64 then return nil end
+    local json = b64url_decode(payload_b64)
+    if not json then return nil end
+    local ok, claims = pcall(cjson.decode, json)
+    if not ok or type(claims) ~= "table" then return nil end
+    return claims[claim_name]
+end
+
+-- Pure: resolve the profile name from config + the Authorization header value.
+--   config.profile_claim          claim that selects the profile (e.g. risk_tier)
+--   config.profile_claim_map      { claim_value = profile_name }
+--   config.fallback_profile_name  strict profile for missing/unmapped claim
+--   config.profile_name           static default (legacy / no claim configured)
+-- Returns: profile_name, source (for logging). Missing/unmapped claim fails CLOSED.
+local function resolve_profile(config, auth_header)
+    if not config.profile_claim or config.profile_claim == "" then
+        return config.profile_name, "static"
+    end
+    local fallback = config.fallback_profile_name or config.profile_name
+    local value = get_claim(auth_header, config.profile_claim)
+    if value == nil then
+        return fallback, "fallback:no-claim"
+    end
+    value = tostring(value)
+    local map = config.profile_claim_map
+    if map and next(map) ~= nil then
+        local mapped = map[value]
+        if mapped then return mapped, "claim-map:" .. value end
+        return fallback, "fallback:unmapped:" .. value
+    end
+    return value, "claim-direct:" .. value
+end
+
+-- Request-scoped: resolve once, memoize across access/response phases via
+-- kong.ctx.shared, log the choice, and stamp an audit header.
+local function resolve_profile_name(config)
+    local cached = kong.ctx.shared.airs_profile_name
+    if cached then return cached end
+    local name, source = resolve_profile(config, kong.request.get_header("authorization"))
+    kong.ctx.shared.airs_profile_name = name
+    log_debug(config, "Resolved AIRS profile: " .. tostring(name) .. " (" .. source .. ")")
+    pcall(function() kong.service.request.set_header("X-AIRS-Profile-Used", name) end)
+    return name
+end
+
+-- ============================================================================
 -- Buffered SSE (text/event-stream) response scanning
 --   Detect a streamed response, reconstruct the assistant text + tool-call args
 --   from the fully buffered body, and scan that with AIRS. Buffered only --
@@ -391,7 +465,7 @@ local function build_mcp_tool_event_payload(config, request_body, response_body)
 
     local payload = {
         tr_id = request_id,
-        ai_profile = { profile_name = config.profile_name },
+        ai_profile = { profile_name = resolve_profile_name(config) },
         contents = { {
             tool_event = {
                 metadata = {
@@ -455,7 +529,7 @@ local function build_prompt_payload(config, scan_type, request_body, response_bo
 
     local payload = {
         tr_id = request_id,
-        ai_profile = { profile_name = config.profile_name },
+        ai_profile = { profile_name = resolve_profile_name(config) },
         contents = { content_object },
         metadata = {
             app_name = config.app_name and ("kong-" .. config.app_name) or "kong",
@@ -737,6 +811,12 @@ SecurePrismaAIRSHandler._sse = {
     extract_prompt = extract_prompt,
     verdict_status = verdict_status,
     apply_scan_limit = apply_scan_limit,
+}
+
+-- Pure (unit-testable) claim-based profile selection helpers.
+SecurePrismaAIRSHandler._profile = {
+    get_claim = get_claim,
+    resolve = resolve_profile,
 }
 
 return SecurePrismaAIRSHandler

--- a/Kong/custom-plugin-v2/handler.lua
+++ b/Kong/custom-plugin-v2/handler.lua
@@ -76,14 +76,31 @@ local function resolve_profile(config, auth_header)
     if value == nil then
         return fallback, "fallback:no-claim"
     end
-    value = tostring(value)
+
+    -- The claim may be a scalar (e.g. risk_tier) or a list (Entra groups/roles
+    -- are arrays). Normalize to an ordered list of string candidates. A token
+    -- typically carries a single group, but iterating is also safe if a list
+    -- ever has more than one value (first mapped value wins).
+    local candidates = {}
+    if type(value) == "table" then
+        for _, v in ipairs(value) do candidates[#candidates + 1] = tostring(v) end
+    else
+        candidates[1] = tostring(value)
+    end
+    if #candidates == 0 then
+        return fallback, "fallback:empty-claim"
+    end
+
     local map = config.profile_claim_map
     if map and next(map) ~= nil then
-        local mapped = map[value]
-        if mapped then return mapped, "claim-map:" .. value end
-        return fallback, "fallback:unmapped:" .. value
+        for _, cv in ipairs(candidates) do
+            local mapped = map[cv]
+            if mapped then return mapped, "claim-map:" .. cv end
+        end
+        return fallback, "fallback:unmapped:" .. candidates[1]
     end
-    return value, "claim-direct:" .. value
+    -- Direct mode: the (single) claim value is itself the profile name.
+    return candidates[1], "claim-direct:" .. candidates[1]
 end
 
 -- Request-scoped: resolve once, memoize across access/response phases via

--- a/Kong/custom-plugin-v2/schema.lua
+++ b/Kong/custom-plugin-v2/schema.lua
@@ -18,6 +18,22 @@ local schema = {
         fields = {
           { api_key = { type = "string", required = true }, },
           { profile_name = { type = "string", required = true }, },
+
+          -- Dynamic per-request profile selection from a signed JWT claim.
+          -- Leave profile_claim unset for the legacy static behavior (profile_name).
+          -- Requires an auth plugin (jwt / openid-connect) in front: this plugin
+          -- runs at priority 1000, below jwt (1450) and openid-connect (1050), so
+          -- the token is already validated when the claim is read.
+          { profile_claim = { type = "string", required = false }, },
+          { profile_claim_map = {
+              type = "map",
+              keys = { type = "string" },
+              values = { type = "string" },
+              required = false,
+            },
+          },
+          -- Strict profile applied when the claim is missing or unmapped (fail closed).
+          { fallback_profile_name = { type = "string", required = false }, },
           { app_name = { type = "string", required = false }, },
           { api_endpoint = {
               type = "string",

--- a/Kong/custom-plugin-v2/spec/profile_selection_spec.lua
+++ b/Kong/custom-plugin-v2/spec/profile_selection_spec.lua
@@ -57,10 +57,19 @@ local function json_decode(s)
       if c == '}' then return o end; assert(c == ',')
     end
   end
+  local function pa()
+    local a = {}; i = i + 1; sk()
+    if s:sub(i, i) == ']' then i = i + 1; return a end
+    while true do
+      sk(); a[#a + 1] = pv(); sk(); local c = s:sub(i, i); i = i + 1
+      if c == ']' then return a end; assert(c == ',')
+    end
+  end
   pv = function()
     sk(); local c = s:sub(i, i)
     if c == '"' then return ps()
     elseif c == '{' then return po()
+    elseif c == '[' then return pa()
     elseif c == 't' then i = i + 4; return true
     elseif c == 'f' then i = i + 5; return false
     elseif c == 'n' then i = i + 4; return nil
@@ -91,6 +100,15 @@ local conf = {
   fallback_profile_name = "strict-production",
 }
 
+-- Entra `groups` claim is an array of group object-IDs (GUIDs), typically one
+-- group per token. Map the group GUID -> AIRS profile.
+local conf_groups = {
+  profile_name = "default-baseline",
+  profile_claim = "groups",
+  profile_claim_map = { ["a1b2c3d4-1111-2222-3333-444455556666"] = "flexible-internal" },
+  fallback_profile_name = "strict-production",
+}
+
 local cases = {
   { "high -> strict",                 conf, tok('{"risk_tier":"high"}'),  "strict-production" },
   { "low -> flexible",                conf, tok('{"risk_tier":"low"}'),   "flexible-internal" },
@@ -102,6 +120,12 @@ local cases = {
     { profile_name = "d", profile_claim = "airs_profile" }, tok('{"airs_profile":"pii-only"}'), "pii-only" },
   { "legacy static (no claim cfg)",
     { profile_name = "chatbot" }, tok('{"risk_tier":"high"}'),            "chatbot" },
+  -- groups array (single GUID)
+  { "groups[guid] -> mapped",         conf_groups, tok('{"groups":["a1b2c3d4-1111-2222-3333-444455556666"]}'), "flexible-internal" },
+  { "groups[unknown] -> fail closed", conf_groups, tok('{"groups":["00000000-0000-0000-0000-000000000000"]}'), "strict-production" },
+  { "groups multi -> first mapped wins",
+    { profile_name = "d", profile_claim = "groups", profile_claim_map = { g2 = "pii-only" }, fallback_profile_name = "strict-production" },
+    tok('{"groups":["g1","g2"]}'), "pii-only" },
 }
 
 local pass, fail = 0, 0

--- a/Kong/custom-plugin-v2/spec/profile_selection_spec.lua
+++ b/Kong/custom-plugin-v2/spec/profile_selection_spec.lua
@@ -1,0 +1,118 @@
+-- Unit test for claim-based profile selection in handler.lua (._profile helpers).
+-- Loads the REAL handler with the two Kong deps stubbed, so it exercises the
+-- shipped code, not a copy. Runnable with plain Lua:
+--   cd Kong/custom-plugin-v2 && lua spec/profile_selection_spec.lua
+-- (Pure helpers only; no Kong/ngx runtime needed beyond base64/json.)
+
+-- ---- base64 (standard) shim for ngx.encode_base64 / ngx.decode_base64 ----
+local B = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+local function b64enc(d)
+  return ((d:gsub('.', function(x)
+    local r, c = '', x:byte()
+    for i = 8, 1, -1 do r = r .. (c % 2 ^ i - c % 2 ^ (i - 1) > 0 and '1' or '0') end
+    return r
+  end) .. '0000'):gsub('%d%d%d?%d?%d?%d?', function(x)
+    if #x < 6 then return '' end
+    local c = 0
+    for i = 1, 6 do c = c + (x:sub(i, i) == '1' and 2 ^ (6 - i) or 0) end
+    return B:sub(c + 1, c + 1)
+  end) .. ({ '', '==', '=' })[#d % 3 + 1])
+end
+local function b64dec(d)
+  d = d:gsub('[^' .. B .. '=]', '')
+  return (d:gsub('.', function(x)
+    if x == '=' then return '' end
+    local r, f = '', (B:find(x) - 1)
+    for i = 6, 1, -1 do r = r .. (f % 2 ^ i - f % 2 ^ (i - 1) > 0 and '1' or '0') end
+    return r
+  end):gsub('%d%d%d?%d?%d?%d?%d?%d?', function(x)
+    if #x ~= 8 then return '' end
+    local c = 0
+    for i = 1, 8 do c = c + (x:sub(i, i) == '1' and 2 ^ (8 - i) or 0) end
+    return string.char(c)
+  end))
+end
+
+-- ---- minimal JSON decoder for the cjson stub ----
+local function json_decode(s)
+  if type(s) ~= "string" then return nil end
+  local i, pv = 1, nil
+  local function sk() while i <= #s and s:sub(i, i):match("%s") do i = i + 1 end end
+  local function ps()
+    i = i + 1; local b = {}
+    while i <= #s do
+      local c = s:sub(i, i)
+      if c == '"' then i = i + 1; return table.concat(b) end
+      if c == '\\' then b[#b + 1] = s:sub(i + 1, i + 1); i = i + 2
+      else b[#b + 1] = c; i = i + 1 end
+    end
+    error("unterminated")
+  end
+  local function po()
+    local o = {}; i = i + 1; sk()
+    if s:sub(i, i) == '}' then i = i + 1; return o end
+    while true do
+      sk(); local k = ps(); sk(); assert(s:sub(i, i) == ':'); i = i + 1
+      o[k] = pv(); sk(); local c = s:sub(i, i); i = i + 1
+      if c == '}' then return o end; assert(c == ',')
+    end
+  end
+  pv = function()
+    sk(); local c = s:sub(i, i)
+    if c == '"' then return ps()
+    elseif c == '{' then return po()
+    elseif c == 't' then i = i + 4; return true
+    elseif c == 'f' then i = i + 5; return false
+    elseif c == 'n' then i = i + 4; return nil
+    else
+      local n = s:match("^%-?%d+%.?%d*", i); assert(n and #n > 0); i = i + #n; return tonumber(n)
+    end
+  end
+  local ok, r = pcall(pv); if not ok then return nil end; return r
+end
+
+-- ---- stub the handler's two require()d deps, then load the REAL handler ----
+package.loaded["resty.http"] = {}
+package.loaded["cjson"] = { decode = json_decode, encode = function() return "{}" end }
+_G.ngx = { encode_base64 = b64enc, decode_base64 = b64dec }
+_G.kong = { ctx = { shared = {} }, request = {}, service = { request = {} } }
+
+local handler = dofile("handler.lua")
+local resolve = handler._profile.resolve
+assert(type(resolve) == "function", "handler._profile.resolve missing")
+
+local function b64url(s) return (b64enc(s):gsub('%+', '-'):gsub('/', '_'):gsub('=', '')) end
+local function tok(json) return "Bearer " .. b64url('{"alg":"RS256"}') .. "." .. b64url(json) .. ".sig" end
+
+local conf = {
+  profile_name = "default-baseline",
+  profile_claim = "risk_tier",
+  profile_claim_map = { high = "strict-production", medium = "default-baseline", low = "flexible-internal" },
+  fallback_profile_name = "strict-production",
+}
+
+local cases = {
+  { "high -> strict",                 conf, tok('{"risk_tier":"high"}'),  "strict-production" },
+  { "low -> flexible",                conf, tok('{"risk_tier":"low"}'),   "flexible-internal" },
+  { "medium -> baseline",             conf, tok('{"risk_tier":"medium"}'),"default-baseline" },
+  { "unmapped -> fail closed",        conf, tok('{"risk_tier":"xyz"}'),   "strict-production" },
+  { "no auth header -> fail closed",  conf, nil,                          "strict-production" },
+  { "garbage token -> fail closed",   conf, "Bearer garbage",            "strict-production" },
+  { "direct mode (no map)",
+    { profile_name = "d", profile_claim = "airs_profile" }, tok('{"airs_profile":"pii-only"}'), "pii-only" },
+  { "legacy static (no claim cfg)",
+    { profile_name = "chatbot" }, tok('{"risk_tier":"high"}'),            "chatbot" },
+}
+
+local pass, fail = 0, 0
+print("=========== handler._profile.resolve (real handler.lua) ===========")
+for _, c in ipairs(cases) do
+  local got, src = resolve(c[2], c[3])
+  local ok = got == c[4]
+  print(string.format("[%s] %-32s want=%-18s got=%-18s (%s)",
+    ok and "PASS" or "FAIL", c[1], c[4], tostring(got), tostring(src)))
+  if ok then pass = pass + 1 else fail = fail + 1 end
+end
+print("-------------------------------------------------------------------")
+print(string.format("RESULTS: %d passed, %d failed", pass, fail))
+os.exit(fail == 0 and 0 or 1)


### PR DESCRIPTION
## What

Adds optional per-request AIRS security-profile selection to the v2 `prisma-airs-intercept` plugin, driven by a signed JWT claim. One shared Kong route can apply app-specific profiles instead of one static profile per route or per gateway.

## Why

Customers running a single shared gateway in front of many apps want a different AIRS profile per request based on caller identity. Today `profile_name` is static per plugin instance. (Multiple profiles per gateway already works via per-route config; this covers the single-shared-endpoint case where apps differ only by the token.)

## How

New optional config, fully backward compatible (unset = today's static behavior):

- `profile_claim` - JWT claim that selects the profile (e.g. `groups`, `roles`)
- `profile_claim_map` - claim value to profile name
- `fallback_profile_name` - strict profile used when the claim is missing or unmapped (fail closed)

The claim may be a scalar or an array (Entra `groups`/`roles` are arrays); the first mapped value wins. A missing, unmapped, or absent claim falls closed to `fallback_profile_name`. The resolved profile is logged and stamped on the upstream request as `X-AIRS-Profile-Used`.

## Security model

Claim decoding trusts that an upstream auth plugin (`jwt` / `openid-connect`) has already validated the token. This plugin runs at priority 1000 - after `jwt` (1450) and `openid-connect` (1050) - so the signature is verified before the claim is read. A missing, unmapped, or unauthenticated claim falls closed to `fallback_profile_name`. The plugin therefore must run behind an auth plugin on any route where claim selection is enabled (documented in the README). This decode-after-auth approach is the one validated end to end below; it keeps the plugin auth-method-agnostic (works with both `jwt` and `openid-connect`) without duplicating signature verification.

## Testing

- Unit: `Kong/custom-plugin-v2/spec/profile_selection_spec.lua` (runs under plain `lua`), 11/11 - claim mapping, array claims, unmapped/missing/malformed -> fail closed, direct mode, legacy static behavior.
- Validated end to end against the live AIRS service: one shared route, group claim -> distinct profiles, correct block/allow verdicts per group, fail-closed on unmapped, no-token rejected.

Backward compatible. v1 mirror can follow if wanted.
