### PR TITLE
custom-plugin-v2 0.2.3: scan Gemini/Vertex responses + latest user turn; opt-in observability headers

### DIFF
--- a/Kong/README.md
+++ b/Kong/README.md
@@ -11,7 +11,7 @@ The contents of this repository are community examples and reference implementat
 | Integration | Prompt Scan | Response Scan | Pre/Post Tool | Multi-Provider | Best For |
 |-------------|:-----------:|:-------------:|:-------------:|:--------------:|----------|
 | [Custom Plugin (v1)](custom-plugin/) | ✅ | ✅ | ❌ | ✅ (via AI Gateway) | LLM-only traffic, full ai-proxy compatibility |
-| [Custom Plugin (v2 — MCP-aware)](custom-plugin-v2/) | ✅ | ✅ | ✅ | ⚠️ (OpenAI + Bedrock Converse native) | LLM + MCP `tools/call` inspection |
+| [Custom Plugin (v2 — MCP-aware)](custom-plugin-v2/) | ✅ | ✅ | ✅ | ⚠️ (OpenAI + Bedrock Converse requests native; Gemini/Vertex responses) | LLM + MCP `tools/call` inspection |
 | [Request Callout](request-callout/) | ✅ | ❌ | ❌ | ❌ | Kong Konnect SaaS, OpenAI only |
 
 ### Multi-Provider Support
@@ -26,7 +26,7 @@ The v1 custom plugin supports all LLM providers when used with [Kong AI Gateway]
 
 Kong's AI Proxy plugin normalizes requests/responses to OpenAI format. See [custom-plugin README](custom-plugin/README.md#multi-provider-support-kong-ai-gateway) for setup.
 
-> v2 runs at priority 1000 (above ai-proxy at 770) and parses OpenAI + Bedrock Converse request shapes directly. Use v1 if you need ai-proxy normalization to run first.
+> v2 runs at priority 1000 (above ai-proxy at 770) and parses OpenAI + Bedrock Converse request shapes directly, and scans Gemini/Vertex responses (`candidates[].content.parts[].text`). Use v1 if you need ai-proxy normalization to run first. v2 also supports opt-in `x-airs-*` observability headers (see the [v2 README](custom-plugin-v2/README.md#configuration)).
 
 ### MCP tool call inspection (v2 only)
 

--- a/Kong/custom-plugin-v2/README.md
+++ b/Kong/custom-plugin-v2/README.md
@@ -6,14 +6,20 @@ v2 extends [v1](../custom-plugin/) with MCP JSON-RPC inspection: `tools/call` re
 
 > Use v1 for OpenAI-only / AI-Gateway-fronted LLM traffic. Use v2 when the same Kong service also brokers MCP tool calls (typically MCP-over-HTTP or SSE-framed remote MCP servers), and/or **serves streamed (`text/event-stream`) LLM responses** that you want scanned.
 
+## What's new in 0.2.3
+
+- **Fix — Gemini/Vertex responses are now scanned.** The response extractor handled only OpenAI (`choices`) and Bedrock (`output`); Gemini/Vertex responses (`candidates[].content.parts[].text`) extracted nothing, so response-side detections passed **unscanned** on the gateway path. Because the plugin runs before `ai-proxy` normalizes, it sees the provider-native body and now parses the Gemini shape.
+- **Fix — multi-turn chat scans the latest user turn.** `extract_prompt` returned the *first* user message; in a multi-turn conversation the client resends the full history, so the plugin re-scanned turn 1 forever and never inspected the new prompt. It now scans the **last** user turn.
+- **Feature (opt-in) — AIRS observability headers.** With `set_observability_headers: true` (default **false**), the plugin emits `x-airs-*` headers on allow and block, for LLM and MCP legs (see the config table).
+
 ## Coverage
 
 > For detection categories and use cases, see the [Prisma AIRS documentation](https://pan.dev/prisma-airs/api/airuntimesecurity/usecases/).
 
 | Scanning Phase | Supported | Description |
 |----------------|:---------:|-------------|
-| Prompt | ✅ | Access phase scans user prompts (OpenAI `messages[]` and Bedrock Converse `content[].text`) |
-| Response | ✅ | Response phase scans LLM completions (OpenAI `choices[].message.content` and Bedrock `output.message.content`) |
+| Prompt | ✅ | Access phase scans user prompts (OpenAI `messages[]` and Bedrock Converse `content[].text`). In multi-turn chat the **latest** user turn is scanned. |
+| Response | ✅ | Response phase scans LLM completions (OpenAI `choices[].message.content`, Bedrock `output.message.content`, and Gemini/Vertex `candidates[].content.parts[].text`) |
 | Streaming | ✅ | `text/event-stream` responses are detected, the streamed text + tool-call args reconstructed from the **fully buffered** body, and scanned before return. The client receives the full response **after completion, not token-by-token**. Covers OpenAI chat, OpenAI Responses, and Anthropic Messages SSE. |
 | Pre-tool call | ✅ | MCP `tools/call` requests scanned as `tool_event` (`input` = arguments JSON) |
 | Post-tool call | ✅ | MCP `tools/call` responses scanned as `tool_event` (`output` = result JSON; SSE framing stripped) |
@@ -29,10 +35,10 @@ v2 extends [v1](../custom-plugin/) with MCP JSON-RPC inspection: `tools/call` re
 | SSE framing | N/A | Strips `event: message\ndata: {...}` envelopes from remote MCP servers before decoding |
 | Buffered SSE response scanning | N/A | Detects `text/event-stream`, reconstructs OpenAI chat / OpenAI Responses / Anthropic Messages text + tool-call args, scans the completed response (LLM path only; MCP behavior unchanged) |
 | Plugin `PRIORITY` | `760` (runs after `ai-proxy` priority `770`) | `1000` (runs **before** `ai-proxy`) |
-| `VERSION` string | `0.3.0` | `0.2.2` |
+| `VERSION` string | `0.3.0` | `0.2.3` |
 | `timeout_ms` / `debug` config | Honored | **Honored** (`timeout_ms` applied to the AIRS call; debug logs gated on `debug`) |
 
-> ⚠️ **Priority change.** v2 runs at priority `1000`, **above** Kong's `ai-proxy` (`770`). If you front a non-OpenAI provider with AI Proxy and rely on Proxy's request normalization, v2 will see the **un-normalized** request body (e.g., Bedrock Converse). v2 handles Bedrock Converse natively, but other shapes (Anthropic Messages, Gemini `contents`, etc.) are not parsed. Use v1 if you want the AIRS scan to see AI-Proxy-normalized OpenAI JSON.
+> ⚠️ **Priority change.** v2 runs at priority `1000`, **above** Kong's `ai-proxy` (`770`). If you front a non-OpenAI provider with AI Proxy and rely on Proxy's request normalization, v2 will see the **un-normalized** request body (e.g., Bedrock Converse). v2 handles Bedrock Converse **request** bodies natively and scans **Gemini/Vertex responses** (`candidates[].content.parts[].text`); other **request** shapes (Anthropic Messages, Gemini `contents`, etc.) are not parsed. Use v1 if you want the AIRS scan to see AI-Proxy-normalized OpenAI JSON.
 
 ## Configuration
 
@@ -52,6 +58,7 @@ v2 extends [v1](../custom-plugin/) with MCP JSON-RPC inspection: `tools/call` re
 | `sse_provider` | No | `auto` | SSE wire format: `auto`, `openai_chat`, `openai_responses`, `anthropic_messages`, or `raw`. `auto` detects from the stream. |
 | `sse_max_scan_chars` | No | `20000` | Max reconstructed chars sent to AIRS before the over-limit policy applies. The `20000` default mirrors the conservative response/tool-output scan cap used by other AIRS reference integrations; the `sse_max_scan_chars` field itself is specific to this Kong v2 plugin (see Notes). Over-limit behavior is governed by `sse_truncation_fail_closed`. |
 | `sse_set_observability_headers` | No | `false` | When `true`, add `x-prisma-airs-sse-detected`, `-scan-mode: buffered`, `-provider`, and `-truncated` response headers. |
+| `set_observability_headers` | No | `false` | When `true`, emit `x-airs-*` response headers on **allow and block**, for **LLM and MCP** legs: `x-airs-verdict`, `x-airs-category`, `x-airs-scan-id`, `x-airs-session-id`, per-phase (`x-airs-request-ms` / `x-airs-response-ms`) + `x-airs-total-ms` AIRS latency, `x-airs-*-tokens` / `x-airs-model`, and the base64 full scan result (`x-airs-request-result` / `x-airs-response-result`). Lets a caller see the AIRS verdict/latency and correlate `scan_id` to SCM, and makes a gateway block non-opaque (which detection fired). |
 | `sse_truncation_fail_closed` | No | `true` | **Secure default.** When `true`, a reconstructed response exceeding `sse_max_scan_chars` cannot be fully scanned, so it is **blocked (403)** rather than returned. Set to `false` to opt into fail-open (scan only the first `sse_max_scan_chars` and return the full response anyway), accepting that content past the cap is returned unscanned. |
 
 ## Dynamic profile selection (claim-based)
@@ -91,10 +98,11 @@ closed to `fallback_profile_name`; with no `profile_claim` set, behavior is the
 legacy static `profile_name`. The resolved profile is logged (with `debug`) and
 stamped on the upstream request as `X-AIRS-Profile-Used`.
 
-Unit tests (pure resolver helpers, no Kong runtime needed):
+Unit tests (pure helpers, no Kong runtime needed):
 
 ```bash
-lua spec/profile_selection_spec.lua
+lua spec/profile_selection_spec.lua   # claim-based profile resolution
+lua spec/extract_prompt_spec.lua      # prompt extraction incl. multi-turn (latest user turn)
 ```
 
 ## Installation
@@ -312,7 +320,7 @@ MCP control messages and MCP response phase scans that find no body **fail open*
 - **Buffered SSE.** Streamed `text/event-stream` responses **are** scanned, but only after the full response is buffered and reconstructed — the client receives the completed response, **not token-by-token**. True per-frame streaming pass-through is not implemented. Requires an **HTTP/1.1 upstream and HTTP/1.1 `proxy_listen`** (Kong response buffering does not apply to HTTP/2 / gRPC upstreams, and AI-Gateway streaming is unsupported on HTTP/2). MCP `text/event-stream` handling is unchanged (the narrow `event: message\ndata: {...}` strip); buffered reconstruction applies to the LLM response path only.
 - Buffered SSE reconstruction is capped at `sse_max_scan_chars` (default 20000). By default (`sse_truncation_fail_closed=true`) a response exceeding the cap **cannot be fully scanned and is blocked (403)** — we do not return a response we could not scan in full. Operators who prefer availability can set `sse_truncation_fail_closed=false` to scan only the first `sse_max_scan_chars` and return the full (partly unscanned) response anyway. Over-limit always emits a `kong.log.warn` and, when `sse_set_observability_headers=true`, an `x-prisma-airs-sse-truncated: true` header.
 - **Provenance of the `20000` default.** It mirrors the conservative response / tool-output scan cap used by other Prisma AIRS reference integrations (e.g. the `codex-hooks`, `claude-code-hooks`, `Cline`, and `Windsurf` integration READMEs all cap scanned output at 20,000 chars). The `sse_max_scan_chars` and `scan_sse_responses` config **fields are specific to this Kong v2 plugin** — no other public AIRS integration exposes an SSE-specific scan-size knob (the Apigee Vertex SSE proxy uses a smaller per-event threshold for cumulative scanning, a different model). Adjust the cap to your AIRS profile's limits and latency budget.
-- LLM request prompt is read from `messages[].content` for the first `role=user` message: string content is scanned directly; array/table content uses the first item's `.text` when present, otherwise the table is JSON-serialized and scanned as-is. This covers OpenAI chat completions, common Anthropic Messages text blocks, and Bedrock Converse. OpenAI Responses is read from top-level `input` (string or array). Only a body with neither a usable `messages` user turn nor `input` falls through to "no prompt found".
+- LLM request prompt is read from `messages[].content` for the **latest** `role=user` message (multi-turn conversations resend the full history, so the newest turn is scanned): string content is scanned directly; array/table content uses the first item's `.text` when present, otherwise the table is JSON-serialized and scanned as-is. This covers OpenAI chat completions, common Anthropic Messages text blocks, and Bedrock Converse. OpenAI Responses is read from top-level `input` (string or array). Only a body with neither a usable `messages` user turn nor `input` falls through to "no prompt found".
 - MCP detection keys off JSON-RPC `method`/`jsonrpc` fields; non-JSON-RPC tool protocols are not recognized
 - Single plugin instance per route — if you need different profiles for LLM vs MCP traffic, split them across separate Kong services/routes
 

--- a/Kong/custom-plugin-v2/handler.lua
+++ b/Kong/custom-plugin-v2/handler.lua
@@ -354,23 +354,31 @@ local function extract_prompt(request_body)
     if not request_body then return nil end
 
     if type(request_body.messages) == "table" then
+        -- Scan the LATEST user turn, not the first. In a multi-turn conversation the
+        -- client sends the full history; prior turns were already scanned, so returning
+        -- on the first user message would re-scan turn 1 forever and never inspect the
+        -- new prompt. Capture the last user message and scan that.
+        local last_user_content
         for _, message in ipairs(request_body.messages) do
             if message.role == "user" then
-                local content = message.content
-                if type(content) == "table" then
-                    -- Bedrock Converse format: content is an array of objects like [{"text":"Hello"}]
-                    if content[1] and content[1].text then
-                        return content[1].text
-                    end
-                    -- Fallback: try to serialize the table
-                    local ok, serialized = pcall(cjson.encode, content)
-                    if ok then
-                        return serialized
-                    end
-                    return nil
-                elseif type(content) == "string" then
-                    return content
+                last_user_content = message.content
+            end
+        end
+        if last_user_content ~= nil then
+            local content = last_user_content
+            if type(content) == "table" then
+                -- Bedrock Converse format: content is an array of objects like [{"text":"Hello"}]
+                if content[1] and content[1].text then
+                    return content[1].text
                 end
+                -- Fallback: try to serialize the table
+                local ok, serialized = pcall(cjson.encode, content)
+                if ok then
+                    return serialized
+                end
+                return nil
+            elseif type(content) == "string" then
+                return content
             end
         end
     end

--- a/Kong/custom-plugin-v2/handler.lua
+++ b/Kong/custom-plugin-v2/handler.lua
@@ -539,6 +539,18 @@ local function build_prompt_payload(config, scan_type, request_body, response_bo
                 elseif type(resp_content) == "string" then
                     content_object.response = resp_content
                 end
+                -- Gemini / Vertex native format: candidates[].content.parts[].text
+                -- (this plugin runs before ai-proxy normalizes, so LLM responses arrive
+                -- in the upstream provider's raw shape).
+            elseif decoded_response.candidates and decoded_response.candidates[1] then
+                local cand = decoded_response.candidates[1]
+                if cand.content and type(cand.content.parts) == "table" then
+                    local parts = {}
+                    for _, prt in ipairs(cand.content.parts) do
+                        if type(prt.text) == "string" then parts[#parts + 1] = prt.text end
+                    end
+                    if #parts > 0 then content_object.response = table.concat(parts, "") end
+                end
             end
         end
     end

--- a/Kong/custom-plugin-v2/handler.lua
+++ b/Kong/custom-plugin-v2/handler.lua
@@ -7,7 +7,7 @@ local cjson = require("cjson")
 
 local SecurePrismaAIRSHandler = {
     PRIORITY = 1000,
-    VERSION = "0.2.2",
+    VERSION = "0.2.3",
 }
 
 local function log_error(reason, verdict)
@@ -552,6 +552,19 @@ local function build_prompt_payload(config, scan_type, request_body, response_bo
                     if #parts > 0 then content_object.response = table.concat(parts, "") end
                 end
             end
+            -- Capture token usage + model so observability headers survive a block
+            -- (the 403 body carries no usage). Gemini: usageMetadata + modelVersion;
+            -- OpenAI/Bedrock: usage + model.
+            local um = decoded_response.usageMetadata
+            if type(um) == "table" then
+                kong.ctx.shared.airs_usage = {
+                    prompt = um.promptTokenCount, completion = um.candidatesTokenCount, total = um.totalTokenCount }
+            elseif type(decoded_response.usage) == "table" then
+                local u = decoded_response.usage
+                kong.ctx.shared.airs_usage = {
+                    prompt = u.prompt_tokens, completion = u.completion_tokens, total = u.total_tokens }
+            end
+            kong.ctx.shared.airs_model = decoded_response.modelVersion or decoded_response.model
         end
     end
 
@@ -589,6 +602,7 @@ local function send_scan(config, payload)
     local httpc = http.new()
     httpc:set_timeout(config.timeout_ms or 5000)
 
+    local t_scan_start = ngx.now()
     local res, err = httpc:request_uri(config.api_endpoint, {
         method = "POST",
         body = request_payload_json,
@@ -602,6 +616,7 @@ local function send_scan(config, payload)
 
     if not res then
         pcall(function() httpc:set_keepalive() end)
+        kong.log.err("AIRS API call failed: " .. tostring(err))
         return "error", "API call failed: " .. tostring(err)
     end
 
@@ -633,7 +648,60 @@ local function send_scan(config, payload)
         return "error", "'action' field not found in API response."
     end
 
+    -- Record scan telemetry for observability headers (see response phase). Each call
+    -- (request scan, response scan) appends one entry; the response phase summarizes them.
+    pcall(function()
+        local scans = kong.ctx.shared.airs_scans or {}
+        scans[#scans + 1] = {
+            action = action,
+            category = res_body_json.category,
+            scan_id = res_body_json.scan_id,
+            session_id = res_body_json.session_id,
+            ms = math.floor((ngx.now() - t_scan_start) * 1000 + 0.5),
+            raw = res_body_str,  -- full AIRS scan result JSON (for the raw-result headers)
+        }
+        kong.ctx.shared.airs_scans = scans
+    end)
+
     return action, "Verdict received from security scan."
+end
+
+-- Kong-coupled: stamp AIRS observability headers from recorded scan telemetry.
+-- Opt-in via config.set_observability_headers. Safe to call in any phase where
+-- response headers can still be set (response phase, or before kong.response.exit).
+local function set_airs_observability_headers(config)
+    if not config.set_observability_headers then return end
+    local scans = kong.ctx.shared.airs_scans
+    if not scans or #scans == 0 then return end
+    local total_ms, verdict, category = 0, "allow", nil
+    for _, s in ipairs(scans) do
+        total_ms = total_ms + (s.ms or 0)
+        if s.action and s.action ~= "allow" then verdict = s.action end
+        if s.category and s.category ~= "benign" then category = s.category end
+    end
+    pcall(kong.response.set_header, "x-airs-verdict", verdict)
+    if category then pcall(kong.response.set_header, "x-airs-category", category) end
+    pcall(kong.response.set_header, "x-airs-total-ms", tostring(total_ms))
+    pcall(kong.response.set_header, "x-airs-scan-count", tostring(#scans))
+    if scans[1] then
+        pcall(kong.response.set_header, "x-airs-request-ms", tostring(scans[1].ms or 0))
+        if scans[1].scan_id then pcall(kong.response.set_header, "x-airs-scan-id", scans[1].scan_id) end
+        if scans[1].session_id then pcall(kong.response.set_header, "x-airs-session-id", scans[1].session_id) end
+        -- Full request-scan result JSON (base64) so the caller shows the same raw detail as the SDK.
+        if scans[1].raw then pcall(kong.response.set_header, "x-airs-request-result", ngx.encode_base64(scans[1].raw)) end
+    end
+    if scans[2] then
+        pcall(kong.response.set_header, "x-airs-response-ms", tostring(scans[2].ms or 0))
+        if scans[2].raw then pcall(kong.response.set_header, "x-airs-response-result", ngx.encode_base64(scans[2].raw)) end
+    end
+    -- Token usage + model captured from the scanned LLM response, so they survive a 403 block.
+    local usage = kong.ctx.shared.airs_usage
+    if type(usage) == "table" then
+        if usage.prompt ~= nil then pcall(kong.response.set_header, "x-airs-prompt-tokens", tostring(usage.prompt)) end
+        if usage.completion ~= nil then pcall(kong.response.set_header, "x-airs-completion-tokens", tostring(usage.completion)) end
+        if usage.total ~= nil then pcall(kong.response.set_header, "x-airs-total-tokens", tostring(usage.total)) end
+    end
+    if kong.ctx.shared.airs_model then pcall(kong.response.set_header, "x-airs-model", tostring(kong.ctx.shared.airs_model)) end
 end
 
 -- Pure: HTTP status a non-allow send_scan verdict maps to (nil if allowed).
@@ -649,11 +717,14 @@ end
 
 -- Kong-coupled: deny a request/response based on a non-allow verdict and halt.
 -- Detailed reason is logged server-side only; the client gets a generic body.
-local function deny(verdict, reason, block_message)
+local function deny(config, verdict, reason, block_message)
     log_error(reason, verdict)
     if verdict_status(verdict) == 503 then
         return kong.response.exit(503, { message = "Security scanning temporarily unavailable." })
     end
+    -- Stamp AIRS verdict/category headers on the 403 so the caller learns WHICH detection
+    -- fired (otherwise a gateway block is opaque). Opt-in via set_observability_headers.
+    set_airs_observability_headers(config)
     return kong.response.exit(403, { message = block_message })
 end
 
@@ -689,7 +760,7 @@ function SecurePrismaAIRSHandler:access(config)
         local verdict, reason = send_scan(config, payload)
 
         if verdict ~= "allow" then
-            return deny(verdict, reason, "MCP request blocked by security policy.")
+            return deny(config, verdict, reason, "MCP request blocked by security policy.")
         end
 
         log_debug(config, "MCP scan allowed for method: " .. mcp_method)
@@ -709,7 +780,7 @@ function SecurePrismaAIRSHandler:access(config)
     local verdict, reason = send_scan(config, payload)
 
     if verdict ~= "allow" then
-        return deny(verdict, reason, "Request blocked by security policy.")
+        return deny(config, verdict, reason, "Request blocked by security policy.")
     end
 
     log_debug(config, "Prompt scan allowed.")
@@ -762,10 +833,13 @@ function SecurePrismaAIRSHandler:response(config)
         local verdict, reason = send_scan(config, payload)
 
         if verdict ~= "allow" then
-            return deny(verdict, reason, "MCP response blocked by security policy.")
+            return deny(config, verdict, reason, "MCP response blocked by security policy.")
         end
 
         log_debug(config, "MCP response scan allowed.")
+        -- Allowed MCP path: stamp AIRS verdict/latency/scan-id headers too, so tool-call
+        -- legs are as observable as LLM legs (per-leg detail + SCM deep-links).
+        set_airs_observability_headers(config)
         return
     end
 
@@ -830,10 +904,12 @@ function SecurePrismaAIRSHandler:response(config)
     local verdict, reason = send_scan(config, payload)
 
     if verdict ~= "allow" then
-        return deny(verdict, reason, "Response blocked by security policy.")
+        return deny(config, verdict, reason, "Response blocked by security policy.")
     end
 
     log_debug(config, "Response scan allowed.")
+    -- Allowed path: stamp AIRS latency/verdict headers on the proxied response.
+    set_airs_observability_headers(config)
 end
 
 -- Pure helpers exposed for the unit test harness (no Kong/ngx dependency).

--- a/Kong/custom-plugin-v2/schema.lua
+++ b/Kong/custom-plugin-v2/schema.lua
@@ -59,6 +59,10 @@ local schema = {
           -- also enforces this max independently, so the bound is belt-and-suspenders.
           { sse_max_scan_chars = { type = "number", required = false, default = 20000, between = { 1, 20000 } }, },
           { sse_set_observability_headers = { type = "boolean", required = false, default = false }, },
+          -- Emit x-airs-* observability headers (verdict, category, scan_id, per-phase +
+          -- total AIRS scan latency) on the proxied/blocked response. Opt-in; lets callers
+          -- see AIRS latency overhead and the block reason, and correlate scan_id to SCM.
+          { set_observability_headers = { type = "boolean", required = false, default = false }, },
           -- Secure default: an over-cap response can't be fully scanned, so block (403)
           -- rather than return it. false = opt into fail-open (scan first N, return all). See README.
           { sse_truncation_fail_closed = { type = "boolean", required = false, default = true }, },

--- a/Kong/custom-plugin-v2/spec/extract_prompt_spec.lua
+++ b/Kong/custom-plugin-v2/spec/extract_prompt_spec.lua
@@ -1,0 +1,86 @@
+-- Unit test for extract_prompt in handler.lua (._sse.extract_prompt).
+-- Loads the REAL handler with its two Kong deps stubbed, so it exercises the
+-- shipped code, not a copy. Runnable with plain Lua:
+--   cd Kong/custom-plugin-v2 && lua spec/extract_prompt_spec.lua
+-- Focus: the multi-turn fix -- in a conversation the client resends the full
+-- history, so the plugin must scan the LATEST user turn, not the first.
+
+-- ---- minimal JSON encoder for the cjson stub (Bedrock serialize fallback) ----
+local function json_encode(v)
+  if type(v) ~= "table" then return tostring(v) end
+  local parts = {}
+  for _, item in ipairs(v) do
+    if type(item) == "table" and item.text then
+      parts[#parts + 1] = '{"text":"' .. tostring(item.text) .. '"}'
+    end
+  end
+  return "[" .. table.concat(parts, ",") .. "]"
+end
+
+-- ---- stub the handler's require()d deps, then load the REAL handler ----
+package.loaded["resty.http"] = {}
+package.loaded["cjson"] = { decode = function() return nil end, encode = json_encode }
+_G.ngx = { encode_base64 = function(s) return s end, decode_base64 = function(s) return s end }
+_G.kong = { ctx = { shared = {} }, request = {}, service = { request = {} } }
+
+local handler = dofile("handler.lua")
+local extract_prompt = handler._sse.extract_prompt
+assert(type(extract_prompt) == "function", "handler._sse.extract_prompt missing")
+
+local cases = {
+  {
+    "multi-turn returns LAST user turn",
+    { messages = {
+        { role = "user", content = "first prompt" },
+        { role = "assistant", content = "an answer" },
+        { role = "user", content = "second prompt" },
+    } },
+    "second prompt",
+  },
+  {
+    "single user turn (string content)",
+    { messages = { { role = "user", content = "hello" } } },
+    "hello",
+  },
+  {
+    "system + user -> user content",
+    { messages = {
+        { role = "system", content = "be helpful" },
+        { role = "user", content = "the question" },
+    } },
+    "the question",
+  },
+  {
+    "Bedrock Converse content array -> text",
+    { messages = { { role = "user", content = { { text = "bedrock prompt" } } } } },
+    "bedrock prompt",
+  },
+  {
+    "OpenAI Responses top-level input (string)",
+    { input = "responses api prompt" },
+    "responses api prompt",
+  },
+  {
+    "no user message -> nil",
+    { messages = { { role = "system", content = "only system" } } },
+    nil,
+  },
+  {
+    "nil body -> nil",
+    nil,
+    nil,
+  },
+}
+
+local pass, fail = 0, 0
+print("=========== handler._sse.extract_prompt (real handler.lua) ===========")
+for _, c in ipairs(cases) do
+  local got = extract_prompt(c[2])
+  local ok = got == c[3]
+  print(string.format("[%s] %-38s want=%-22s got=%s",
+    ok and "PASS" or "FAIL", c[1], tostring(c[3]), tostring(got)))
+  if ok then pass = pass + 1 else fail = fail + 1 end
+end
+print("----------------------------------------------------------------------")
+print(string.format("RESULTS: %d passed, %d failed", pass, fail))
+os.exit(fail == 0 and 0 or 1)


### PR DESCRIPTION
## Summary

Bumps the Kong `custom-plugin-v2` (Prisma AIRS) plugin `0.2.2 → 0.2.3` with **two security fixes** and **one opt-in observability feature**. No breaking changes; no new/parallel plugin.

Anyone running the current `custom-plugin-v2` with **Gemini/Vertex** or **multi-turn chat** has a silent scanning gap today — the two fixes close those.

## Changes

### `fix:` scan Gemini/Vertex responses
The response extractor handled only OpenAI (`choices`) and Bedrock (`output`). For **Gemini/Vertex** (`candidates[].content.parts[].text`) it extracted nothing, so response-side detections (DLP, toxic output, DB-security) passed **unscanned** on the gateway path. The plugin runs before `ai-proxy` normalizes, so it sees the provider-native body — now parsed.

### `fix:` scan the latest user turn in multi-turn chat
`extract_prompt` returned the **first** user message. In a multi-turn conversation the client resends the full history, so the plugin re-scanned turn 1 forever and never inspected the new prompt. Now scans the **last** user turn.

### `feat:` opt-in AIRS observability headers
With `set_observability_headers: true` (default **false**) the plugin emits `x-airs-*` headers on both allow and block, for LLM and MCP legs: `verdict`, `category`, `scan_id`, `session_id`, per-phase + total AIRS latency, token usage/model, and the base64 full scan result. Lets a caller see the AIRS verdict/latency and correlate `scan_id` to SCM, and makes a gateway block non-opaque (which detection fired). Backward-compatible: default-off; `deny()` gained an internal `config` arg only.

## Files
- `Kong/custom-plugin-v2/handler.lua` — Gemini response parsing; multi-turn extract; observability telemetry + `set_airs_observability_headers()`; `VERSION` → `0.2.3`.
- `Kong/custom-plugin-v2/schema.lua` — new opt-in `set_observability_headers` field.
- `Kong/custom-plugin-v2/README.md` — document fixes + observability; corrected multi-provider claim (v2 now response-parses Gemini/Vertex); version.
- `Kong/custom-plugin-v2/spec/extract_prompt_spec.lua` — unit test for prompt extraction incl. multi-turn.
- `Kong/README.md` — coverage table + multi-provider note.

## Testing
- Unit specs (pure helpers, no Kong runtime) green against the real `handler.lua`:
  - `lua spec/profile_selection_spec.lua` → 11 passed
  - `lua spec/extract_prompt_spec.lua` → 7 passed
- `handler.lua` + `schema.lua` compile under `kong/kong-gateway:3.14.0.2` (`luajit -bl`).
- Exercised end-to-end on a Konnect **hybrid data plane** (Kong 3.14.0.2), Gemini/Vertex via `ai-proxy`: Gemini responses scanned, multi-turn newest-turn scanned, and `x-airs-*` headers observed on allow + 403.

## Notes for maintainers
- Opened as a **Draft**. Per `CONTRIBUTING.md` ("open an issue first for major changes"), happy to file issues and/or split the two `fix:` commits from the `feat:` into separate PRs if you'd prefer to land the security fixes first.
- Commits are separated `fix:` / `fix:` / `feat:` for easy review or cherry-pick.
