### PR TITLE
fix(hooks/codex): block via stdout JSON — exit-2 blocks die in Codex's shell wrapper (fail-open)

### DIFF
--- a/Hooks/ClaudeCode/bash/.claude/hooks/airs-hooks.sh
+++ b/Hooks/ClaudeCode/bash/.claude/hooks/airs-hooks.sh
@@ -186,12 +186,21 @@ render() {
         esac
       fi ;;
     codex)
+      # Codex 0.150.0 (verified in codex-rs source + measured live): blocking is
+      # STDOUT-JSON on exit 0, NEVER exit 2 — Codex reads its shell WRAPPER's exit
+      # status verbatim (PowerShell collapses any child failure to 1) and any code
+      # other than 0/2 is "hook exited with code {n}" = fail-OPEN. Also: stderr is
+      # ignored on exit 0, so warnings ride the universal systemMessage field, and
+      # an empty "reason" converts a block into a failure (jq -e guards upstream).
       if [ "$kind" = "block" ]; then
         case "$IEVENT" in
-          UserPromptSubmit|PreToolUse) code=2 ;;
+          UserPromptSubmit) out="$(jq -nc --arg r "$text" '{decision:"block",reason:$r}')" ;;
+          PreToolUse)  out="$(jq -nc --arg r "$text" '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}')" ;;
           PostToolUse) out="$(jq -nc --arg r "$text" '{decision:"block",reason:$r,hookSpecificOutput:{hookEventName:"PostToolUse"}}')" ;;
           Stop)        out="$(jq -nc --arg r "$text" '{continue:false,stopReason:$r}')" ;;
         esac
+      elif [ "$kind" = "warn" ]; then
+        out="$(jq -nc --arg m "$text" '{systemMessage:("[Prisma AIRS] "+$m)}')"
       else
         [ "$IEVENT" = "Stop" ] && out='{"continue": true}'
       fi ;;
@@ -279,7 +288,14 @@ emit_nojq_block() {
       exit 0 ;;
     cline)
       printf '{"cancel":true,"errorMessage":"%s"}' "$msg"; exit 0 ;;
-    *) # codex / devin / gemini / antigravity block input via exit 2 (no stdout needed)
+    codex)
+      # Codex blocks via stdout JSON on exit 0 (exit codes die in its shell wrapper).
+      case "$IEVENT" in
+        PreToolUse)       printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}' "$msg" ;;
+        UserPromptSubmit) printf '{"decision":"block","reason":"%s"}' "$msg" ;;
+      esac
+      printf '\n🚫 %s\n\n' "$msg" >&2; exit 0 ;;
+    *) # devin / gemini / antigravity block input via exit 2 (no stdout needed)
       printf '\n🚫 %s\n\n' "$msg" >&2; exit 2 ;;
   esac
 }

--- a/Hooks/ClaudeCode/nodejs/.claude/hooks/hooks.mjs
+++ b/Hooks/ClaudeCode/nodejs/.claude/hooks/hooks.mjs
@@ -389,6 +389,27 @@ function names(toolName) {
   }
   return { server: `claude-code/${toolName || "unknown"}`, tool: toolName || "unknown" };
 }
+function primaryOutputSurface(resp) {
+  if (typeof resp === "string") return resp.length > 0 ? resp : null;
+  if (resp == null || typeof resp !== "object") return null;
+  const values = [];
+  const walk = (v, depth) => {
+    if (depth > 64 || values.length > 2) return;
+    if (typeof v === "string") {
+      if (v.length > 0 && !values.includes(v)) values.push(v);
+      return;
+    }
+    if (Array.isArray(v)) {
+      for (const x of v) walk(x, depth + 1);
+      return;
+    }
+    if (v && typeof v === "object") {
+      for (const x of Object.values(v)) walk(x, depth + 1);
+    }
+  };
+  walk(resp, 0);
+  return values.length === 1 ? values[0] : null;
+}
 function collectStrings(value, out = [], depth = 0) {
   if (depth > 64) return out;
   if (typeof value === "string") {
@@ -523,9 +544,11 @@ async function tryMask(input, plan, cfg, scanMeta, event) {
     return null;
   }
   if (event === "PostToolUse" && plan.kind === "toolOutput") {
-    const v = await scan(cfg, { response: plan.text }, scanMeta);
+    const surface = primaryOutputSurface(input.tool_response ?? input.tool_result);
+    if (!surface || surface.length > cfg.maxContentChars) return null;
+    const v = await scan(cfg, { response: surface }, scanMeta);
     const masked = v.maskedResponse;
-    if (isPureDlpMask(v, masked, plan.text)) {
+    if (isPureDlpMask(v, masked, surface)) {
       return { kind: "maskOutput", updatedOutput: masked, note: `Prisma AIRS masked sensitive data in ${input.tool_name} output (scan_id: ${v.scanId})` };
     }
     if (v.action === "block") return { kind: "block", reason: reasonText(v) };
@@ -654,21 +677,23 @@ var codexAdapter = {
       case "allow":
         return event === "Stop" ? { exitCode: 0, stdout: '{"continue": true}' } : { exitCode: 0 };
       case "warn":
-        return event === "Stop" ? { exitCode: 0, stdout: '{"continue": true}', stderr: `[Prisma AIRS] ${decision.message}
-` } : { exitCode: 0, stderr: `[Prisma AIRS] ${decision.message}
-` };
+        return { exitCode: 0, stdout: JSON.stringify({ systemMessage: `[Prisma AIRS] ${decision.message}` }) };
       case "block": {
-        const stderr = `
-\u{1F6AB} ${decision.reason}
-
-`;
-        if (event === "UserPromptSubmit" || event === "PreToolUse") {
-          return { exitCode: 2, stderr };
+        const reason = (decision.reason ?? "").trim() || "Blocked by Prisma AIRS";
+        if (event === "UserPromptSubmit") {
+          return { exitCode: 0, stdout: JSON.stringify({ decision: "block", reason }) };
+        }
+        if (event === "PreToolUse") {
+          return { exitCode: 0, stdout: JSON.stringify({ hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "deny",
+            permissionDecisionReason: reason
+          } }) };
         }
         if (event === "PostToolUse") {
-          return { exitCode: 0, stdout: JSON.stringify({ decision: "block", reason: decision.reason, hookSpecificOutput: { hookEventName: "PostToolUse" } }), stderr };
+          return { exitCode: 0, stdout: JSON.stringify({ decision: "block", reason, hookSpecificOutput: { hookEventName: "PostToolUse" } }) };
         }
-        return { exitCode: 0, stdout: JSON.stringify({ continue: false, stopReason: decision.reason }), stderr };
+        return { exitCode: 0, stdout: JSON.stringify({ continue: false, stopReason: reason }) };
       }
       // Codex can't rewrite; masking is gated off for it, so these are unreachable.
       // Defensive: the content was a primary-allowed pure-DLP surface — allow.

--- a/Hooks/ClaudeCode/powershell/.claude/hooks/airs-hooks.ps1
+++ b/Hooks/ClaudeCode/powershell/.claude/hooks/airs-hooks.ps1
@@ -123,13 +123,20 @@ function Render([string]$kind, [string]$text) {
       }
     }
     'codex' {
+      # Codex 0.150.0 (verified in codex-rs source + measured live on Windows):
+      # blocking is STDOUT-JSON on exit 0, NEVER exit 2 — Codex reads its shell
+      # WRAPPER's exit status verbatim and PowerShell collapses any child failure
+      # to 1; anything other than 0/2 is "hook exited with code {n}" = fail-OPEN.
+      # stderr is ignored on exit 0, so warnings ride systemMessage.
       if ($kind -eq 'block') {
         switch ($IEvent) {
-          { $_ -in @('UserPromptSubmit','PreToolUse') } { $code = 2 }
+          'UserPromptSubmit' { $out = @{ decision='block'; reason=$text } | ConvertTo-Json -Compress -Depth 6 }
+          'PreToolUse'       { $out = @{ hookSpecificOutput = @{ hookEventName='PreToolUse'; permissionDecision='deny'; permissionDecisionReason=$text } } | ConvertTo-Json -Compress -Depth 6 }
           'PostToolUse' { $out = @{ decision='block'; reason=$text; hookSpecificOutput=@{ hookEventName='PostToolUse' } } | ConvertTo-Json -Compress -Depth 6 }
           'Stop'        { $out = @{ continue=$false; stopReason=$text } | ConvertTo-Json -Compress -Depth 6 }
         }
-      } elseif ($IEvent -eq 'Stop') { $out = '{"continue":true}' }
+      } elseif ($kind -eq 'warn') { $out = @{ systemMessage = ("[Prisma AIRS] " + $text) } | ConvertTo-Json -Compress -Depth 6 }
+      elseif ($IEvent -eq 'Stop') { $out = '{"continue":true}' }
     }
     'cursor' {
       # Cursor reads decisions from STDOUT. Pre-tool hard-blocks via permission=deny.

--- a/Hooks/Cline/bash/.clinerules/hooks/airs-hooks.sh
+++ b/Hooks/Cline/bash/.clinerules/hooks/airs-hooks.sh
@@ -186,12 +186,21 @@ render() {
         esac
       fi ;;
     codex)
+      # Codex 0.150.0 (verified in codex-rs source + measured live): blocking is
+      # STDOUT-JSON on exit 0, NEVER exit 2 — Codex reads its shell WRAPPER's exit
+      # status verbatim (PowerShell collapses any child failure to 1) and any code
+      # other than 0/2 is "hook exited with code {n}" = fail-OPEN. Also: stderr is
+      # ignored on exit 0, so warnings ride the universal systemMessage field, and
+      # an empty "reason" converts a block into a failure (jq -e guards upstream).
       if [ "$kind" = "block" ]; then
         case "$IEVENT" in
-          UserPromptSubmit|PreToolUse) code=2 ;;
+          UserPromptSubmit) out="$(jq -nc --arg r "$text" '{decision:"block",reason:$r}')" ;;
+          PreToolUse)  out="$(jq -nc --arg r "$text" '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}')" ;;
           PostToolUse) out="$(jq -nc --arg r "$text" '{decision:"block",reason:$r,hookSpecificOutput:{hookEventName:"PostToolUse"}}')" ;;
           Stop)        out="$(jq -nc --arg r "$text" '{continue:false,stopReason:$r}')" ;;
         esac
+      elif [ "$kind" = "warn" ]; then
+        out="$(jq -nc --arg m "$text" '{systemMessage:("[Prisma AIRS] "+$m)}')"
       else
         [ "$IEVENT" = "Stop" ] && out='{"continue": true}'
       fi ;;
@@ -279,7 +288,14 @@ emit_nojq_block() {
       exit 0 ;;
     cline)
       printf '{"cancel":true,"errorMessage":"%s"}' "$msg"; exit 0 ;;
-    *) # codex / devin / gemini / antigravity block input via exit 2 (no stdout needed)
+    codex)
+      # Codex blocks via stdout JSON on exit 0 (exit codes die in its shell wrapper).
+      case "$IEVENT" in
+        PreToolUse)       printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}' "$msg" ;;
+        UserPromptSubmit) printf '{"decision":"block","reason":"%s"}' "$msg" ;;
+      esac
+      printf '\n🚫 %s\n\n' "$msg" >&2; exit 0 ;;
+    *) # devin / gemini / antigravity block input via exit 2 (no stdout needed)
       printf '\n🚫 %s\n\n' "$msg" >&2; exit 2 ;;
   esac
 }

--- a/Hooks/Cline/nodejs/.clinerules/hooks/hooks.mjs
+++ b/Hooks/Cline/nodejs/.clinerules/hooks/hooks.mjs
@@ -389,6 +389,27 @@ function names(toolName) {
   }
   return { server: `claude-code/${toolName || "unknown"}`, tool: toolName || "unknown" };
 }
+function primaryOutputSurface(resp) {
+  if (typeof resp === "string") return resp.length > 0 ? resp : null;
+  if (resp == null || typeof resp !== "object") return null;
+  const values = [];
+  const walk = (v, depth) => {
+    if (depth > 64 || values.length > 2) return;
+    if (typeof v === "string") {
+      if (v.length > 0 && !values.includes(v)) values.push(v);
+      return;
+    }
+    if (Array.isArray(v)) {
+      for (const x of v) walk(x, depth + 1);
+      return;
+    }
+    if (v && typeof v === "object") {
+      for (const x of Object.values(v)) walk(x, depth + 1);
+    }
+  };
+  walk(resp, 0);
+  return values.length === 1 ? values[0] : null;
+}
 function collectStrings(value, out = [], depth = 0) {
   if (depth > 64) return out;
   if (typeof value === "string") {
@@ -523,9 +544,11 @@ async function tryMask(input, plan, cfg, scanMeta, event) {
     return null;
   }
   if (event === "PostToolUse" && plan.kind === "toolOutput") {
-    const v = await scan(cfg, { response: plan.text }, scanMeta);
+    const surface = primaryOutputSurface(input.tool_response ?? input.tool_result);
+    if (!surface || surface.length > cfg.maxContentChars) return null;
+    const v = await scan(cfg, { response: surface }, scanMeta);
     const masked = v.maskedResponse;
-    if (isPureDlpMask(v, masked, plan.text)) {
+    if (isPureDlpMask(v, masked, surface)) {
       return { kind: "maskOutput", updatedOutput: masked, note: `Prisma AIRS masked sensitive data in ${input.tool_name} output (scan_id: ${v.scanId})` };
     }
     if (v.action === "block") return { kind: "block", reason: reasonText(v) };
@@ -654,21 +677,23 @@ var codexAdapter = {
       case "allow":
         return event === "Stop" ? { exitCode: 0, stdout: '{"continue": true}' } : { exitCode: 0 };
       case "warn":
-        return event === "Stop" ? { exitCode: 0, stdout: '{"continue": true}', stderr: `[Prisma AIRS] ${decision.message}
-` } : { exitCode: 0, stderr: `[Prisma AIRS] ${decision.message}
-` };
+        return { exitCode: 0, stdout: JSON.stringify({ systemMessage: `[Prisma AIRS] ${decision.message}` }) };
       case "block": {
-        const stderr = `
-\u{1F6AB} ${decision.reason}
-
-`;
-        if (event === "UserPromptSubmit" || event === "PreToolUse") {
-          return { exitCode: 2, stderr };
+        const reason = (decision.reason ?? "").trim() || "Blocked by Prisma AIRS";
+        if (event === "UserPromptSubmit") {
+          return { exitCode: 0, stdout: JSON.stringify({ decision: "block", reason }) };
+        }
+        if (event === "PreToolUse") {
+          return { exitCode: 0, stdout: JSON.stringify({ hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "deny",
+            permissionDecisionReason: reason
+          } }) };
         }
         if (event === "PostToolUse") {
-          return { exitCode: 0, stdout: JSON.stringify({ decision: "block", reason: decision.reason, hookSpecificOutput: { hookEventName: "PostToolUse" } }), stderr };
+          return { exitCode: 0, stdout: JSON.stringify({ decision: "block", reason, hookSpecificOutput: { hookEventName: "PostToolUse" } }) };
         }
-        return { exitCode: 0, stdout: JSON.stringify({ continue: false, stopReason: decision.reason }), stderr };
+        return { exitCode: 0, stdout: JSON.stringify({ continue: false, stopReason: reason }) };
       }
       // Codex can't rewrite; masking is gated off for it, so these are unreachable.
       // Defensive: the content was a primary-allowed pure-DLP surface — allow.

--- a/Hooks/Cline/powershell/.clinerules/hooks/airs-hooks.ps1
+++ b/Hooks/Cline/powershell/.clinerules/hooks/airs-hooks.ps1
@@ -123,13 +123,20 @@ function Render([string]$kind, [string]$text) {
       }
     }
     'codex' {
+      # Codex 0.150.0 (verified in codex-rs source + measured live on Windows):
+      # blocking is STDOUT-JSON on exit 0, NEVER exit 2 — Codex reads its shell
+      # WRAPPER's exit status verbatim and PowerShell collapses any child failure
+      # to 1; anything other than 0/2 is "hook exited with code {n}" = fail-OPEN.
+      # stderr is ignored on exit 0, so warnings ride systemMessage.
       if ($kind -eq 'block') {
         switch ($IEvent) {
-          { $_ -in @('UserPromptSubmit','PreToolUse') } { $code = 2 }
+          'UserPromptSubmit' { $out = @{ decision='block'; reason=$text } | ConvertTo-Json -Compress -Depth 6 }
+          'PreToolUse'       { $out = @{ hookSpecificOutput = @{ hookEventName='PreToolUse'; permissionDecision='deny'; permissionDecisionReason=$text } } | ConvertTo-Json -Compress -Depth 6 }
           'PostToolUse' { $out = @{ decision='block'; reason=$text; hookSpecificOutput=@{ hookEventName='PostToolUse' } } | ConvertTo-Json -Compress -Depth 6 }
           'Stop'        { $out = @{ continue=$false; stopReason=$text } | ConvertTo-Json -Compress -Depth 6 }
         }
-      } elseif ($IEvent -eq 'Stop') { $out = '{"continue":true}' }
+      } elseif ($kind -eq 'warn') { $out = @{ systemMessage = ("[Prisma AIRS] " + $text) } | ConvertTo-Json -Compress -Depth 6 }
+      elseif ($IEvent -eq 'Stop') { $out = '{"continue":true}' }
     }
     'cursor' {
       # Cursor reads decisions from STDOUT. Pre-tool hard-blocks via permission=deny.

--- a/Hooks/Codex/README.md
+++ b/Hooks/Codex/README.md
@@ -48,8 +48,8 @@ Each folder is self-contained (engine + wiring + `.codex/`). Shared `example.env
 
 <div align="center"><sub>✅ hard-block &nbsp;·&nbsp; ⚠️ scan + alert / redact &nbsp;·&nbsp; ❌ no usable surface in the hook contract</sub></div>
 
-> [!WARNING]
-> **Codex enforcement is contract-derived — not yet validated on a live Codex CLI.** The ✅ marks reflect the engine emitting Codex's documented block wire format (exit 2 via `.codex/hooks.json`), but the hard-block has **not** been confirmed end-to-end against a real Codex client, and Codex's docs on its deny mechanism are ambiguous (several Claude-style fields are documented as accepted-but-fail-open). Treat **pre-tool hard-block as pending live validation**; confirm with `tests/run-tests.sh live` against a real Codex session before relying on it.
+> [!IMPORTANT]
+> **Validated against Codex CLI 0.150.0 (live + source).** A live 0.150.0 session measured the previous exit-2 prompt block being reported as `hook (failed) — hook exited with code 1` and answered anyway: Codex reads its **shell wrapper's** exit status verbatim (a PowerShell-style wrapper collapses any child failure to 1), and every exit code other than 0/2 is a hook *failure* = **fail-open**. The engines now block via the stdout-JSON forms Codex's own integration suite pins (`codex-rs` tag `rust-v0.150.0`): `{"decision":"block","reason":…}` on `UserPromptSubmit`/`PostToolUse`, `permissionDecision:"deny"` on `PreToolUse`, `{"continue":false}` on `Stop` — always exit 0, stdout carrying nothing but the JSON. Three Codex-side gates still apply and are called out below: hooks must be **trusted** (interactive prompt; re-fires when `hooks.json` changes), **synchronous** (`async:true` can never block), and the `hooks.json` must parse (Codex rejects unknown keys — including `"//"` comment keys — and discards the whole file with a one-line warning). Warnings ride `{"systemMessage":…}` — stderr is ignored on exit 0. Re-run `tests/run-tests.sh live` after any Codex CLI upgrade; the wire contract is version-measured, not guaranteed.
 ```mermaid
 flowchart LR
     P["Prompt<br/>🛡️ block"] --> T["Tool call<br/>🛡️ block"]
@@ -62,7 +62,7 @@ flowchart LR
 
 <br>
 
-Codex CLI reads hooks from `.codex/hooks.json` on the Claude-compatible contract: the engine scans the prompt on input, the model's answer on `Stop`, and tool input/output as a `tool_event` (`tools/call`) for **indirect prompt injection**, and renders a block as **exit code 2** on `PreToolUse`. **Caveat — pending live validation:** this hard-block is **contract-derived, not yet verified against a live Codex CLI**, and Codex's own docs on which deny fields it honors are ambiguous (some Claude-style fields are documented as accepted-but-fail-open). Until a live Codex block is confirmed (`tests/run-tests.sh live`), treat pre-tool enforcement as unproven.
+Codex CLI reads hooks from the project's `.codex/hooks.json`: the engine scans the prompt on input, the model's answer on `Stop`, and tool input/output as a `tool_event` (`tools/call`) for **indirect prompt injection**. Blocks are rendered as **stdout JSON on exit 0** (never exit 2 — Codex reports its shell wrapper's exit status, and any code other than 0/2 fails open as a hook *failure*). The forms match Codex's own integration fixtures at `rust-v0.150.0`: a blocked prompt produces **zero model requests** and a red `UserPromptSubmit hook (blocked)` cell. Requires `codex_hooks = true`, a **trust** decision (interactive; re-fires on every `hooks.json` edit), and synchronous handlers. Known Codex-side limits, measured: the **VS Code extension does not run hooks at all** (CLI-only today), and `codex exec` skips hooks silently unless trust was persisted or `--dangerously-bypass-hook-trust` is passed.
 </details>
 
 <div align="center">

--- a/Hooks/Codex/bash/.codex/hooks.json
+++ b/Hooks/Codex/bash/.codex/hooks.json
@@ -1,5 +1,5 @@
 {
-  "//": "Codex CLI. Copy .codex/ into your project (or ~/). Requires codex_hooks=true in ~/.codex/config.toml.",
+  "description": "Prisma AIRS hooks for Codex CLI. Copy .codex/ into your PROJECT (hooks are project-scope). Use ABSOLUTE command paths (hooks run with cwd = the turn directory). Requires codex_hooks=true in ~/.codex/config.toml AND a trust decision: run `codex` interactively in the project once and choose Trust (untrusted hooks are silently skipped; trust re-fires on every edit of this file). Never set async:true \u2014 async handlers cannot block.",
   "hooks": {
     "UserPromptSubmit": [
       {

--- a/Hooks/Codex/bash/.codex/hooks/airs-hooks.sh
+++ b/Hooks/Codex/bash/.codex/hooks/airs-hooks.sh
@@ -186,12 +186,21 @@ render() {
         esac
       fi ;;
     codex)
+      # Codex 0.150.0 (verified in codex-rs source + measured live): blocking is
+      # STDOUT-JSON on exit 0, NEVER exit 2 — Codex reads its shell WRAPPER's exit
+      # status verbatim (PowerShell collapses any child failure to 1) and any code
+      # other than 0/2 is "hook exited with code {n}" = fail-OPEN. Also: stderr is
+      # ignored on exit 0, so warnings ride the universal systemMessage field, and
+      # an empty "reason" converts a block into a failure (jq -e guards upstream).
       if [ "$kind" = "block" ]; then
         case "$IEVENT" in
-          UserPromptSubmit|PreToolUse) code=2 ;;
+          UserPromptSubmit) out="$(jq -nc --arg r "$text" '{decision:"block",reason:$r}')" ;;
+          PreToolUse)  out="$(jq -nc --arg r "$text" '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}')" ;;
           PostToolUse) out="$(jq -nc --arg r "$text" '{decision:"block",reason:$r,hookSpecificOutput:{hookEventName:"PostToolUse"}}')" ;;
           Stop)        out="$(jq -nc --arg r "$text" '{continue:false,stopReason:$r}')" ;;
         esac
+      elif [ "$kind" = "warn" ]; then
+        out="$(jq -nc --arg m "$text" '{systemMessage:("[Prisma AIRS] "+$m)}')"
       else
         [ "$IEVENT" = "Stop" ] && out='{"continue": true}'
       fi ;;
@@ -279,7 +288,14 @@ emit_nojq_block() {
       exit 0 ;;
     cline)
       printf '{"cancel":true,"errorMessage":"%s"}' "$msg"; exit 0 ;;
-    *) # codex / devin / gemini / antigravity block input via exit 2 (no stdout needed)
+    codex)
+      # Codex blocks via stdout JSON on exit 0 (exit codes die in its shell wrapper).
+      case "$IEVENT" in
+        PreToolUse)       printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}' "$msg" ;;
+        UserPromptSubmit) printf '{"decision":"block","reason":"%s"}' "$msg" ;;
+      esac
+      printf '\n🚫 %s\n\n' "$msg" >&2; exit 0 ;;
+    *) # devin / gemini / antigravity block input via exit 2 (no stdout needed)
       printf '\n🚫 %s\n\n' "$msg" >&2; exit 2 ;;
   esac
 }

--- a/Hooks/Codex/nodejs/.codex/hooks.json
+++ b/Hooks/Codex/nodejs/.codex/hooks.json
@@ -1,5 +1,5 @@
 {
-  "//": "Codex CLI. Copy .codex/ into your project (or ~/). Requires codex_hooks=true in ~/.codex/config.toml.",
+  "description": "Prisma AIRS hooks for Codex CLI. Copy .codex/ into your PROJECT (hooks are project-scope). Use ABSOLUTE command paths (hooks run with cwd = the turn directory). Requires codex_hooks=true in ~/.codex/config.toml AND a trust decision: run `codex` interactively in the project once and choose Trust (untrusted hooks are silently skipped; trust re-fires on every edit of this file). Never set async:true \u2014 async handlers cannot block.",
   "hooks": {
     "UserPromptSubmit": [
       {

--- a/Hooks/Codex/nodejs/.codex/hooks/hooks.mjs
+++ b/Hooks/Codex/nodejs/.codex/hooks/hooks.mjs
@@ -389,6 +389,27 @@ function names(toolName) {
   }
   return { server: `claude-code/${toolName || "unknown"}`, tool: toolName || "unknown" };
 }
+function primaryOutputSurface(resp) {
+  if (typeof resp === "string") return resp.length > 0 ? resp : null;
+  if (resp == null || typeof resp !== "object") return null;
+  const values = [];
+  const walk = (v, depth) => {
+    if (depth > 64 || values.length > 2) return;
+    if (typeof v === "string") {
+      if (v.length > 0 && !values.includes(v)) values.push(v);
+      return;
+    }
+    if (Array.isArray(v)) {
+      for (const x of v) walk(x, depth + 1);
+      return;
+    }
+    if (v && typeof v === "object") {
+      for (const x of Object.values(v)) walk(x, depth + 1);
+    }
+  };
+  walk(resp, 0);
+  return values.length === 1 ? values[0] : null;
+}
 function collectStrings(value, out = [], depth = 0) {
   if (depth > 64) return out;
   if (typeof value === "string") {
@@ -523,9 +544,11 @@ async function tryMask(input, plan, cfg, scanMeta, event) {
     return null;
   }
   if (event === "PostToolUse" && plan.kind === "toolOutput") {
-    const v = await scan(cfg, { response: plan.text }, scanMeta);
+    const surface = primaryOutputSurface(input.tool_response ?? input.tool_result);
+    if (!surface || surface.length > cfg.maxContentChars) return null;
+    const v = await scan(cfg, { response: surface }, scanMeta);
     const masked = v.maskedResponse;
-    if (isPureDlpMask(v, masked, plan.text)) {
+    if (isPureDlpMask(v, masked, surface)) {
       return { kind: "maskOutput", updatedOutput: masked, note: `Prisma AIRS masked sensitive data in ${input.tool_name} output (scan_id: ${v.scanId})` };
     }
     if (v.action === "block") return { kind: "block", reason: reasonText(v) };
@@ -654,21 +677,23 @@ var codexAdapter = {
       case "allow":
         return event === "Stop" ? { exitCode: 0, stdout: '{"continue": true}' } : { exitCode: 0 };
       case "warn":
-        return event === "Stop" ? { exitCode: 0, stdout: '{"continue": true}', stderr: `[Prisma AIRS] ${decision.message}
-` } : { exitCode: 0, stderr: `[Prisma AIRS] ${decision.message}
-` };
+        return { exitCode: 0, stdout: JSON.stringify({ systemMessage: `[Prisma AIRS] ${decision.message}` }) };
       case "block": {
-        const stderr = `
-\u{1F6AB} ${decision.reason}
-
-`;
-        if (event === "UserPromptSubmit" || event === "PreToolUse") {
-          return { exitCode: 2, stderr };
+        const reason = (decision.reason ?? "").trim() || "Blocked by Prisma AIRS";
+        if (event === "UserPromptSubmit") {
+          return { exitCode: 0, stdout: JSON.stringify({ decision: "block", reason }) };
+        }
+        if (event === "PreToolUse") {
+          return { exitCode: 0, stdout: JSON.stringify({ hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "deny",
+            permissionDecisionReason: reason
+          } }) };
         }
         if (event === "PostToolUse") {
-          return { exitCode: 0, stdout: JSON.stringify({ decision: "block", reason: decision.reason, hookSpecificOutput: { hookEventName: "PostToolUse" } }), stderr };
+          return { exitCode: 0, stdout: JSON.stringify({ decision: "block", reason, hookSpecificOutput: { hookEventName: "PostToolUse" } }) };
         }
-        return { exitCode: 0, stdout: JSON.stringify({ continue: false, stopReason: decision.reason }), stderr };
+        return { exitCode: 0, stdout: JSON.stringify({ continue: false, stopReason: reason }) };
       }
       // Codex can't rewrite; masking is gated off for it, so these are unreachable.
       // Defensive: the content was a primary-allowed pure-DLP surface — allow.

--- a/Hooks/Codex/powershell/.codex/hooks.json
+++ b/Hooks/Codex/powershell/.codex/hooks.json
@@ -1,5 +1,5 @@
 {
-  "//": "Codex CLI. Copy .codex/ into your project (or ~/). Requires codex_hooks=true in ~/.codex/config.toml.",
+  "description": "Prisma AIRS hooks for Codex CLI. Copy .codex/ into your PROJECT (hooks are project-scope). Use ABSOLUTE command paths (hooks run with cwd = the turn directory). Requires codex_hooks=true in ~/.codex/config.toml AND a trust decision: run `codex` interactively in the project once and choose Trust (untrusted hooks are silently skipped; trust re-fires on every edit of this file). Never set async:true \u2014 async handlers cannot block.",
   "hooks": {
     "UserPromptSubmit": [
       {

--- a/Hooks/Codex/powershell/.codex/hooks/airs-hooks.ps1
+++ b/Hooks/Codex/powershell/.codex/hooks/airs-hooks.ps1
@@ -123,13 +123,20 @@ function Render([string]$kind, [string]$text) {
       }
     }
     'codex' {
+      # Codex 0.150.0 (verified in codex-rs source + measured live on Windows):
+      # blocking is STDOUT-JSON on exit 0, NEVER exit 2 — Codex reads its shell
+      # WRAPPER's exit status verbatim and PowerShell collapses any child failure
+      # to 1; anything other than 0/2 is "hook exited with code {n}" = fail-OPEN.
+      # stderr is ignored on exit 0, so warnings ride systemMessage.
       if ($kind -eq 'block') {
         switch ($IEvent) {
-          { $_ -in @('UserPromptSubmit','PreToolUse') } { $code = 2 }
+          'UserPromptSubmit' { $out = @{ decision='block'; reason=$text } | ConvertTo-Json -Compress -Depth 6 }
+          'PreToolUse'       { $out = @{ hookSpecificOutput = @{ hookEventName='PreToolUse'; permissionDecision='deny'; permissionDecisionReason=$text } } | ConvertTo-Json -Compress -Depth 6 }
           'PostToolUse' { $out = @{ decision='block'; reason=$text; hookSpecificOutput=@{ hookEventName='PostToolUse' } } | ConvertTo-Json -Compress -Depth 6 }
           'Stop'        { $out = @{ continue=$false; stopReason=$text } | ConvertTo-Json -Compress -Depth 6 }
         }
-      } elseif ($IEvent -eq 'Stop') { $out = '{"continue":true}' }
+      } elseif ($kind -eq 'warn') { $out = @{ systemMessage = ("[Prisma AIRS] " + $text) } | ConvertTo-Json -Compress -Depth 6 }
+      elseif ($IEvent -eq 'Stop') { $out = '{"continue":true}' }
     }
     'cursor' {
       # Cursor reads decisions from STDOUT. Pre-tool hard-blocks via permission=deny.

--- a/Hooks/Cursor/bash/.cursor/hooks/airs-hooks.sh
+++ b/Hooks/Cursor/bash/.cursor/hooks/airs-hooks.sh
@@ -186,12 +186,21 @@ render() {
         esac
       fi ;;
     codex)
+      # Codex 0.150.0 (verified in codex-rs source + measured live): blocking is
+      # STDOUT-JSON on exit 0, NEVER exit 2 — Codex reads its shell WRAPPER's exit
+      # status verbatim (PowerShell collapses any child failure to 1) and any code
+      # other than 0/2 is "hook exited with code {n}" = fail-OPEN. Also: stderr is
+      # ignored on exit 0, so warnings ride the universal systemMessage field, and
+      # an empty "reason" converts a block into a failure (jq -e guards upstream).
       if [ "$kind" = "block" ]; then
         case "$IEVENT" in
-          UserPromptSubmit|PreToolUse) code=2 ;;
+          UserPromptSubmit) out="$(jq -nc --arg r "$text" '{decision:"block",reason:$r}')" ;;
+          PreToolUse)  out="$(jq -nc --arg r "$text" '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}')" ;;
           PostToolUse) out="$(jq -nc --arg r "$text" '{decision:"block",reason:$r,hookSpecificOutput:{hookEventName:"PostToolUse"}}')" ;;
           Stop)        out="$(jq -nc --arg r "$text" '{continue:false,stopReason:$r}')" ;;
         esac
+      elif [ "$kind" = "warn" ]; then
+        out="$(jq -nc --arg m "$text" '{systemMessage:("[Prisma AIRS] "+$m)}')"
       else
         [ "$IEVENT" = "Stop" ] && out='{"continue": true}'
       fi ;;
@@ -279,7 +288,14 @@ emit_nojq_block() {
       exit 0 ;;
     cline)
       printf '{"cancel":true,"errorMessage":"%s"}' "$msg"; exit 0 ;;
-    *) # codex / devin / gemini / antigravity block input via exit 2 (no stdout needed)
+    codex)
+      # Codex blocks via stdout JSON on exit 0 (exit codes die in its shell wrapper).
+      case "$IEVENT" in
+        PreToolUse)       printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}' "$msg" ;;
+        UserPromptSubmit) printf '{"decision":"block","reason":"%s"}' "$msg" ;;
+      esac
+      printf '\n🚫 %s\n\n' "$msg" >&2; exit 0 ;;
+    *) # devin / gemini / antigravity block input via exit 2 (no stdout needed)
       printf '\n🚫 %s\n\n' "$msg" >&2; exit 2 ;;
   esac
 }

--- a/Hooks/Cursor/nodejs/.cursor/hooks/hooks.mjs
+++ b/Hooks/Cursor/nodejs/.cursor/hooks/hooks.mjs
@@ -389,6 +389,27 @@ function names(toolName) {
   }
   return { server: `claude-code/${toolName || "unknown"}`, tool: toolName || "unknown" };
 }
+function primaryOutputSurface(resp) {
+  if (typeof resp === "string") return resp.length > 0 ? resp : null;
+  if (resp == null || typeof resp !== "object") return null;
+  const values = [];
+  const walk = (v, depth) => {
+    if (depth > 64 || values.length > 2) return;
+    if (typeof v === "string") {
+      if (v.length > 0 && !values.includes(v)) values.push(v);
+      return;
+    }
+    if (Array.isArray(v)) {
+      for (const x of v) walk(x, depth + 1);
+      return;
+    }
+    if (v && typeof v === "object") {
+      for (const x of Object.values(v)) walk(x, depth + 1);
+    }
+  };
+  walk(resp, 0);
+  return values.length === 1 ? values[0] : null;
+}
 function collectStrings(value, out = [], depth = 0) {
   if (depth > 64) return out;
   if (typeof value === "string") {
@@ -523,9 +544,11 @@ async function tryMask(input, plan, cfg, scanMeta, event) {
     return null;
   }
   if (event === "PostToolUse" && plan.kind === "toolOutput") {
-    const v = await scan(cfg, { response: plan.text }, scanMeta);
+    const surface = primaryOutputSurface(input.tool_response ?? input.tool_result);
+    if (!surface || surface.length > cfg.maxContentChars) return null;
+    const v = await scan(cfg, { response: surface }, scanMeta);
     const masked = v.maskedResponse;
-    if (isPureDlpMask(v, masked, plan.text)) {
+    if (isPureDlpMask(v, masked, surface)) {
       return { kind: "maskOutput", updatedOutput: masked, note: `Prisma AIRS masked sensitive data in ${input.tool_name} output (scan_id: ${v.scanId})` };
     }
     if (v.action === "block") return { kind: "block", reason: reasonText(v) };
@@ -654,21 +677,23 @@ var codexAdapter = {
       case "allow":
         return event === "Stop" ? { exitCode: 0, stdout: '{"continue": true}' } : { exitCode: 0 };
       case "warn":
-        return event === "Stop" ? { exitCode: 0, stdout: '{"continue": true}', stderr: `[Prisma AIRS] ${decision.message}
-` } : { exitCode: 0, stderr: `[Prisma AIRS] ${decision.message}
-` };
+        return { exitCode: 0, stdout: JSON.stringify({ systemMessage: `[Prisma AIRS] ${decision.message}` }) };
       case "block": {
-        const stderr = `
-\u{1F6AB} ${decision.reason}
-
-`;
-        if (event === "UserPromptSubmit" || event === "PreToolUse") {
-          return { exitCode: 2, stderr };
+        const reason = (decision.reason ?? "").trim() || "Blocked by Prisma AIRS";
+        if (event === "UserPromptSubmit") {
+          return { exitCode: 0, stdout: JSON.stringify({ decision: "block", reason }) };
+        }
+        if (event === "PreToolUse") {
+          return { exitCode: 0, stdout: JSON.stringify({ hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "deny",
+            permissionDecisionReason: reason
+          } }) };
         }
         if (event === "PostToolUse") {
-          return { exitCode: 0, stdout: JSON.stringify({ decision: "block", reason: decision.reason, hookSpecificOutput: { hookEventName: "PostToolUse" } }), stderr };
+          return { exitCode: 0, stdout: JSON.stringify({ decision: "block", reason, hookSpecificOutput: { hookEventName: "PostToolUse" } }) };
         }
-        return { exitCode: 0, stdout: JSON.stringify({ continue: false, stopReason: decision.reason }), stderr };
+        return { exitCode: 0, stdout: JSON.stringify({ continue: false, stopReason: reason }) };
       }
       // Codex can't rewrite; masking is gated off for it, so these are unreachable.
       // Defensive: the content was a primary-allowed pure-DLP surface — allow.

--- a/Hooks/Cursor/powershell/.cursor/hooks/airs-hooks.ps1
+++ b/Hooks/Cursor/powershell/.cursor/hooks/airs-hooks.ps1
@@ -123,13 +123,20 @@ function Render([string]$kind, [string]$text) {
       }
     }
     'codex' {
+      # Codex 0.150.0 (verified in codex-rs source + measured live on Windows):
+      # blocking is STDOUT-JSON on exit 0, NEVER exit 2 — Codex reads its shell
+      # WRAPPER's exit status verbatim and PowerShell collapses any child failure
+      # to 1; anything other than 0/2 is "hook exited with code {n}" = fail-OPEN.
+      # stderr is ignored on exit 0, so warnings ride systemMessage.
       if ($kind -eq 'block') {
         switch ($IEvent) {
-          { $_ -in @('UserPromptSubmit','PreToolUse') } { $code = 2 }
+          'UserPromptSubmit' { $out = @{ decision='block'; reason=$text } | ConvertTo-Json -Compress -Depth 6 }
+          'PreToolUse'       { $out = @{ hookSpecificOutput = @{ hookEventName='PreToolUse'; permissionDecision='deny'; permissionDecisionReason=$text } } | ConvertTo-Json -Compress -Depth 6 }
           'PostToolUse' { $out = @{ decision='block'; reason=$text; hookSpecificOutput=@{ hookEventName='PostToolUse' } } | ConvertTo-Json -Compress -Depth 6 }
           'Stop'        { $out = @{ continue=$false; stopReason=$text } | ConvertTo-Json -Compress -Depth 6 }
         }
-      } elseif ($IEvent -eq 'Stop') { $out = '{"continue":true}' }
+      } elseif ($kind -eq 'warn') { $out = @{ systemMessage = ("[Prisma AIRS] " + $text) } | ConvertTo-Json -Compress -Depth 6 }
+      elseif ($IEvent -eq 'Stop') { $out = '{"continue":true}' }
     }
     'cursor' {
       # Cursor reads decisions from STDOUT. Pre-tool hard-blocks via permission=deny.

--- a/Hooks/Devin/bash/.devin/hooks/airs-hooks.sh
+++ b/Hooks/Devin/bash/.devin/hooks/airs-hooks.sh
@@ -186,12 +186,21 @@ render() {
         esac
       fi ;;
     codex)
+      # Codex 0.150.0 (verified in codex-rs source + measured live): blocking is
+      # STDOUT-JSON on exit 0, NEVER exit 2 — Codex reads its shell WRAPPER's exit
+      # status verbatim (PowerShell collapses any child failure to 1) and any code
+      # other than 0/2 is "hook exited with code {n}" = fail-OPEN. Also: stderr is
+      # ignored on exit 0, so warnings ride the universal systemMessage field, and
+      # an empty "reason" converts a block into a failure (jq -e guards upstream).
       if [ "$kind" = "block" ]; then
         case "$IEVENT" in
-          UserPromptSubmit|PreToolUse) code=2 ;;
+          UserPromptSubmit) out="$(jq -nc --arg r "$text" '{decision:"block",reason:$r}')" ;;
+          PreToolUse)  out="$(jq -nc --arg r "$text" '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}')" ;;
           PostToolUse) out="$(jq -nc --arg r "$text" '{decision:"block",reason:$r,hookSpecificOutput:{hookEventName:"PostToolUse"}}')" ;;
           Stop)        out="$(jq -nc --arg r "$text" '{continue:false,stopReason:$r}')" ;;
         esac
+      elif [ "$kind" = "warn" ]; then
+        out="$(jq -nc --arg m "$text" '{systemMessage:("[Prisma AIRS] "+$m)}')"
       else
         [ "$IEVENT" = "Stop" ] && out='{"continue": true}'
       fi ;;
@@ -279,7 +288,14 @@ emit_nojq_block() {
       exit 0 ;;
     cline)
       printf '{"cancel":true,"errorMessage":"%s"}' "$msg"; exit 0 ;;
-    *) # codex / devin / gemini / antigravity block input via exit 2 (no stdout needed)
+    codex)
+      # Codex blocks via stdout JSON on exit 0 (exit codes die in its shell wrapper).
+      case "$IEVENT" in
+        PreToolUse)       printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}' "$msg" ;;
+        UserPromptSubmit) printf '{"decision":"block","reason":"%s"}' "$msg" ;;
+      esac
+      printf '\n🚫 %s\n\n' "$msg" >&2; exit 0 ;;
+    *) # devin / gemini / antigravity block input via exit 2 (no stdout needed)
       printf '\n🚫 %s\n\n' "$msg" >&2; exit 2 ;;
   esac
 }

--- a/Hooks/Devin/nodejs/.devin/hooks/hooks.mjs
+++ b/Hooks/Devin/nodejs/.devin/hooks/hooks.mjs
@@ -389,6 +389,27 @@ function names(toolName) {
   }
   return { server: `claude-code/${toolName || "unknown"}`, tool: toolName || "unknown" };
 }
+function primaryOutputSurface(resp) {
+  if (typeof resp === "string") return resp.length > 0 ? resp : null;
+  if (resp == null || typeof resp !== "object") return null;
+  const values = [];
+  const walk = (v, depth) => {
+    if (depth > 64 || values.length > 2) return;
+    if (typeof v === "string") {
+      if (v.length > 0 && !values.includes(v)) values.push(v);
+      return;
+    }
+    if (Array.isArray(v)) {
+      for (const x of v) walk(x, depth + 1);
+      return;
+    }
+    if (v && typeof v === "object") {
+      for (const x of Object.values(v)) walk(x, depth + 1);
+    }
+  };
+  walk(resp, 0);
+  return values.length === 1 ? values[0] : null;
+}
 function collectStrings(value, out = [], depth = 0) {
   if (depth > 64) return out;
   if (typeof value === "string") {
@@ -523,9 +544,11 @@ async function tryMask(input, plan, cfg, scanMeta, event) {
     return null;
   }
   if (event === "PostToolUse" && plan.kind === "toolOutput") {
-    const v = await scan(cfg, { response: plan.text }, scanMeta);
+    const surface = primaryOutputSurface(input.tool_response ?? input.tool_result);
+    if (!surface || surface.length > cfg.maxContentChars) return null;
+    const v = await scan(cfg, { response: surface }, scanMeta);
     const masked = v.maskedResponse;
-    if (isPureDlpMask(v, masked, plan.text)) {
+    if (isPureDlpMask(v, masked, surface)) {
       return { kind: "maskOutput", updatedOutput: masked, note: `Prisma AIRS masked sensitive data in ${input.tool_name} output (scan_id: ${v.scanId})` };
     }
     if (v.action === "block") return { kind: "block", reason: reasonText(v) };
@@ -654,21 +677,23 @@ var codexAdapter = {
       case "allow":
         return event === "Stop" ? { exitCode: 0, stdout: '{"continue": true}' } : { exitCode: 0 };
       case "warn":
-        return event === "Stop" ? { exitCode: 0, stdout: '{"continue": true}', stderr: `[Prisma AIRS] ${decision.message}
-` } : { exitCode: 0, stderr: `[Prisma AIRS] ${decision.message}
-` };
+        return { exitCode: 0, stdout: JSON.stringify({ systemMessage: `[Prisma AIRS] ${decision.message}` }) };
       case "block": {
-        const stderr = `
-\u{1F6AB} ${decision.reason}
-
-`;
-        if (event === "UserPromptSubmit" || event === "PreToolUse") {
-          return { exitCode: 2, stderr };
+        const reason = (decision.reason ?? "").trim() || "Blocked by Prisma AIRS";
+        if (event === "UserPromptSubmit") {
+          return { exitCode: 0, stdout: JSON.stringify({ decision: "block", reason }) };
+        }
+        if (event === "PreToolUse") {
+          return { exitCode: 0, stdout: JSON.stringify({ hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "deny",
+            permissionDecisionReason: reason
+          } }) };
         }
         if (event === "PostToolUse") {
-          return { exitCode: 0, stdout: JSON.stringify({ decision: "block", reason: decision.reason, hookSpecificOutput: { hookEventName: "PostToolUse" } }), stderr };
+          return { exitCode: 0, stdout: JSON.stringify({ decision: "block", reason, hookSpecificOutput: { hookEventName: "PostToolUse" } }) };
         }
-        return { exitCode: 0, stdout: JSON.stringify({ continue: false, stopReason: decision.reason }), stderr };
+        return { exitCode: 0, stdout: JSON.stringify({ continue: false, stopReason: reason }) };
       }
       // Codex can't rewrite; masking is gated off for it, so these are unreachable.
       // Defensive: the content was a primary-allowed pure-DLP surface — allow.

--- a/Hooks/Devin/powershell/.devin/hooks/airs-hooks.ps1
+++ b/Hooks/Devin/powershell/.devin/hooks/airs-hooks.ps1
@@ -123,13 +123,20 @@ function Render([string]$kind, [string]$text) {
       }
     }
     'codex' {
+      # Codex 0.150.0 (verified in codex-rs source + measured live on Windows):
+      # blocking is STDOUT-JSON on exit 0, NEVER exit 2 — Codex reads its shell
+      # WRAPPER's exit status verbatim and PowerShell collapses any child failure
+      # to 1; anything other than 0/2 is "hook exited with code {n}" = fail-OPEN.
+      # stderr is ignored on exit 0, so warnings ride systemMessage.
       if ($kind -eq 'block') {
         switch ($IEvent) {
-          { $_ -in @('UserPromptSubmit','PreToolUse') } { $code = 2 }
+          'UserPromptSubmit' { $out = @{ decision='block'; reason=$text } | ConvertTo-Json -Compress -Depth 6 }
+          'PreToolUse'       { $out = @{ hookSpecificOutput = @{ hookEventName='PreToolUse'; permissionDecision='deny'; permissionDecisionReason=$text } } | ConvertTo-Json -Compress -Depth 6 }
           'PostToolUse' { $out = @{ decision='block'; reason=$text; hookSpecificOutput=@{ hookEventName='PostToolUse' } } | ConvertTo-Json -Compress -Depth 6 }
           'Stop'        { $out = @{ continue=$false; stopReason=$text } | ConvertTo-Json -Compress -Depth 6 }
         }
-      } elseif ($IEvent -eq 'Stop') { $out = '{"continue":true}' }
+      } elseif ($kind -eq 'warn') { $out = @{ systemMessage = ("[Prisma AIRS] " + $text) } | ConvertTo-Json -Compress -Depth 6 }
+      elseif ($IEvent -eq 'Stop') { $out = '{"continue":true}' }
     }
     'cursor' {
       # Cursor reads decisions from STDOUT. Pre-tool hard-blocks via permission=deny.

--- a/Hooks/GeminiCLI/bash/.gemini/hooks/airs-hooks.sh
+++ b/Hooks/GeminiCLI/bash/.gemini/hooks/airs-hooks.sh
@@ -186,12 +186,21 @@ render() {
         esac
       fi ;;
     codex)
+      # Codex 0.150.0 (verified in codex-rs source + measured live): blocking is
+      # STDOUT-JSON on exit 0, NEVER exit 2 — Codex reads its shell WRAPPER's exit
+      # status verbatim (PowerShell collapses any child failure to 1) and any code
+      # other than 0/2 is "hook exited with code {n}" = fail-OPEN. Also: stderr is
+      # ignored on exit 0, so warnings ride the universal systemMessage field, and
+      # an empty "reason" converts a block into a failure (jq -e guards upstream).
       if [ "$kind" = "block" ]; then
         case "$IEVENT" in
-          UserPromptSubmit|PreToolUse) code=2 ;;
+          UserPromptSubmit) out="$(jq -nc --arg r "$text" '{decision:"block",reason:$r}')" ;;
+          PreToolUse)  out="$(jq -nc --arg r "$text" '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}')" ;;
           PostToolUse) out="$(jq -nc --arg r "$text" '{decision:"block",reason:$r,hookSpecificOutput:{hookEventName:"PostToolUse"}}')" ;;
           Stop)        out="$(jq -nc --arg r "$text" '{continue:false,stopReason:$r}')" ;;
         esac
+      elif [ "$kind" = "warn" ]; then
+        out="$(jq -nc --arg m "$text" '{systemMessage:("[Prisma AIRS] "+$m)}')"
       else
         [ "$IEVENT" = "Stop" ] && out='{"continue": true}'
       fi ;;
@@ -279,7 +288,14 @@ emit_nojq_block() {
       exit 0 ;;
     cline)
       printf '{"cancel":true,"errorMessage":"%s"}' "$msg"; exit 0 ;;
-    *) # codex / devin / gemini / antigravity block input via exit 2 (no stdout needed)
+    codex)
+      # Codex blocks via stdout JSON on exit 0 (exit codes die in its shell wrapper).
+      case "$IEVENT" in
+        PreToolUse)       printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}' "$msg" ;;
+        UserPromptSubmit) printf '{"decision":"block","reason":"%s"}' "$msg" ;;
+      esac
+      printf '\n🚫 %s\n\n' "$msg" >&2; exit 0 ;;
+    *) # devin / gemini / antigravity block input via exit 2 (no stdout needed)
       printf '\n🚫 %s\n\n' "$msg" >&2; exit 2 ;;
   esac
 }

--- a/Hooks/GeminiCLI/nodejs/.gemini/hooks/hooks.mjs
+++ b/Hooks/GeminiCLI/nodejs/.gemini/hooks/hooks.mjs
@@ -389,6 +389,27 @@ function names(toolName) {
   }
   return { server: `claude-code/${toolName || "unknown"}`, tool: toolName || "unknown" };
 }
+function primaryOutputSurface(resp) {
+  if (typeof resp === "string") return resp.length > 0 ? resp : null;
+  if (resp == null || typeof resp !== "object") return null;
+  const values = [];
+  const walk = (v, depth) => {
+    if (depth > 64 || values.length > 2) return;
+    if (typeof v === "string") {
+      if (v.length > 0 && !values.includes(v)) values.push(v);
+      return;
+    }
+    if (Array.isArray(v)) {
+      for (const x of v) walk(x, depth + 1);
+      return;
+    }
+    if (v && typeof v === "object") {
+      for (const x of Object.values(v)) walk(x, depth + 1);
+    }
+  };
+  walk(resp, 0);
+  return values.length === 1 ? values[0] : null;
+}
 function collectStrings(value, out = [], depth = 0) {
   if (depth > 64) return out;
   if (typeof value === "string") {
@@ -523,9 +544,11 @@ async function tryMask(input, plan, cfg, scanMeta, event) {
     return null;
   }
   if (event === "PostToolUse" && plan.kind === "toolOutput") {
-    const v = await scan(cfg, { response: plan.text }, scanMeta);
+    const surface = primaryOutputSurface(input.tool_response ?? input.tool_result);
+    if (!surface || surface.length > cfg.maxContentChars) return null;
+    const v = await scan(cfg, { response: surface }, scanMeta);
     const masked = v.maskedResponse;
-    if (isPureDlpMask(v, masked, plan.text)) {
+    if (isPureDlpMask(v, masked, surface)) {
       return { kind: "maskOutput", updatedOutput: masked, note: `Prisma AIRS masked sensitive data in ${input.tool_name} output (scan_id: ${v.scanId})` };
     }
     if (v.action === "block") return { kind: "block", reason: reasonText(v) };
@@ -654,21 +677,23 @@ var codexAdapter = {
       case "allow":
         return event === "Stop" ? { exitCode: 0, stdout: '{"continue": true}' } : { exitCode: 0 };
       case "warn":
-        return event === "Stop" ? { exitCode: 0, stdout: '{"continue": true}', stderr: `[Prisma AIRS] ${decision.message}
-` } : { exitCode: 0, stderr: `[Prisma AIRS] ${decision.message}
-` };
+        return { exitCode: 0, stdout: JSON.stringify({ systemMessage: `[Prisma AIRS] ${decision.message}` }) };
       case "block": {
-        const stderr = `
-\u{1F6AB} ${decision.reason}
-
-`;
-        if (event === "UserPromptSubmit" || event === "PreToolUse") {
-          return { exitCode: 2, stderr };
+        const reason = (decision.reason ?? "").trim() || "Blocked by Prisma AIRS";
+        if (event === "UserPromptSubmit") {
+          return { exitCode: 0, stdout: JSON.stringify({ decision: "block", reason }) };
+        }
+        if (event === "PreToolUse") {
+          return { exitCode: 0, stdout: JSON.stringify({ hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "deny",
+            permissionDecisionReason: reason
+          } }) };
         }
         if (event === "PostToolUse") {
-          return { exitCode: 0, stdout: JSON.stringify({ decision: "block", reason: decision.reason, hookSpecificOutput: { hookEventName: "PostToolUse" } }), stderr };
+          return { exitCode: 0, stdout: JSON.stringify({ decision: "block", reason, hookSpecificOutput: { hookEventName: "PostToolUse" } }) };
         }
-        return { exitCode: 0, stdout: JSON.stringify({ continue: false, stopReason: decision.reason }), stderr };
+        return { exitCode: 0, stdout: JSON.stringify({ continue: false, stopReason: reason }) };
       }
       // Codex can't rewrite; masking is gated off for it, so these are unreachable.
       // Defensive: the content was a primary-allowed pure-DLP surface — allow.

--- a/Hooks/GeminiCLI/powershell/.gemini/hooks/airs-hooks.ps1
+++ b/Hooks/GeminiCLI/powershell/.gemini/hooks/airs-hooks.ps1
@@ -123,13 +123,20 @@ function Render([string]$kind, [string]$text) {
       }
     }
     'codex' {
+      # Codex 0.150.0 (verified in codex-rs source + measured live on Windows):
+      # blocking is STDOUT-JSON on exit 0, NEVER exit 2 — Codex reads its shell
+      # WRAPPER's exit status verbatim and PowerShell collapses any child failure
+      # to 1; anything other than 0/2 is "hook exited with code {n}" = fail-OPEN.
+      # stderr is ignored on exit 0, so warnings ride systemMessage.
       if ($kind -eq 'block') {
         switch ($IEvent) {
-          { $_ -in @('UserPromptSubmit','PreToolUse') } { $code = 2 }
+          'UserPromptSubmit' { $out = @{ decision='block'; reason=$text } | ConvertTo-Json -Compress -Depth 6 }
+          'PreToolUse'       { $out = @{ hookSpecificOutput = @{ hookEventName='PreToolUse'; permissionDecision='deny'; permissionDecisionReason=$text } } | ConvertTo-Json -Compress -Depth 6 }
           'PostToolUse' { $out = @{ decision='block'; reason=$text; hookSpecificOutput=@{ hookEventName='PostToolUse' } } | ConvertTo-Json -Compress -Depth 6 }
           'Stop'        { $out = @{ continue=$false; stopReason=$text } | ConvertTo-Json -Compress -Depth 6 }
         }
-      } elseif ($IEvent -eq 'Stop') { $out = '{"continue":true}' }
+      } elseif ($kind -eq 'warn') { $out = @{ systemMessage = ("[Prisma AIRS] " + $text) } | ConvertTo-Json -Compress -Depth 6 }
+      elseif ($IEvent -eq 'Stop') { $out = '{"continue":true}' }
     }
     'cursor' {
       # Cursor reads decisions from STDOUT. Pre-tool hard-blocks via permission=deny.


### PR DESCRIPTION
## Summary

Codex CLI never honored the hooks' prompt-level block: the engines signaled a `UserPromptSubmit` deny by exiting 2, but Codex reports the exit status of the **shell wrapper** it spawns around the hook, and a PowerShell-style wrapper collapses any non-zero child exit to **1**. Any exit code other than 0/2 lands in Codex's fail-open catch-all — `UserPromptSubmit hook (failed): hook exited with code 1` — and the model answers anyway.

This was measured live on **Codex CLI 0.150.0** (Windows, `codex` TUI): AIRS returned `block` (`malicious [toxic_content]`), the engine chose to block, Codex logged the hook as *failed* and answered. PR #60's README already flagged Codex enforcement as *"contract-derived — pending live validation"*; this is that validation, and the fix.

## The contract (verified in Codex's source, tag `rust-v0.150.0`)

- Canonical block = **exit 0** + stdout of exactly `{"decision":"block","reason":"<non-empty>"}` — the same fixture Codex's own integration suite pins (`core/tests/suite/hooks.rs`); a blocked turn issues **zero** model requests.
- `reason` must be non-empty after trim, or the block is converted to a failure (fail-open).
- Every output wire is serde `deny_unknown_fields`: no extra keys, nothing else on stdout — and a top-level `"//"` key in `hooks.json` rejects the **whole file** with one scrolled-past warning.
- stderr is **ignored on exit 0**, so warnings must ride `{"systemMessage":...}`.
- Only synchronous, **trusted** handlers can block (`async:true` never blocks; untrusted files' hooks silently never run).

## Changes

- All three engines (node / bash / PowerShell), all agents: Codex `UserPromptSubmit` block → stdout JSON on exit 0; `PreToolUse` → `hookSpecificOutput.permissionDecision:"deny"`; warns → `systemMessage`. `PostToolUse`/`Stop` renders unchanged (already honored).
- bash no-jq fallback: the codex arm now emits static stdout JSON instead of exiting 2.
- `Codex/*/.codex/hooks.json`: the fatal top-level `"//"` key replaced with `description` (carrying the trust / absolute-path / no-async guidance).
- `Codex/README.md`: the pending-validation caveat replaced with the measured 0.150.0 contract and known limits (the VS Code extension runs no hooks; `codex exec` needs persisted trust or `--dangerously-bypass-hook-trust`).
- Node engine rebuilt; its DLP output rewrite now redacts the raw single-field surface instead of the key-collecting scan aggregate.

## Validation

`Codex/tests/run-tests.sh` stub + offline lanes pass (node + bash; the PowerShell arm mirrors bash 1:1 — re-validated on a Windows box). The wire contract is version-measured against 0.150.0; re-run `tests/run-tests.sh live` after Codex CLI upgrades.
