### PR TITLE
fix(hooks/cline): Windows shims must be <Event>.ps1 — the shipped .cmd files are invisible to Cline's discovery

### DIFF
--- a/Hooks/Cline/README.md
+++ b/Hooks/Cline/README.md
@@ -11,10 +11,22 @@
 
 ## Quick start
 
-**1 · Copy the `.clinerules/` folder into your Cline project** — pick the runtime you have:
+**1 · Copy the `.clinerules/` folder into your Cline project** — pick the cell for your OS **and** runtime:
 ```bash
-cp -r nodejs/.clinerules  /path/to/your/project/      # or  bash/.clinerules  ·  powershell/.clinerules
+cp -r nodejs/.clinerules  /path/to/your/project/      # macOS/Linux (or bash/.clinerules)
+# Windows: use powershell/.clinerules — it is the ONLY cell Cline can discover on win32
 ```
+
+> [!IMPORTANT]
+> **Copying the folder is not enough — hooks are OFF until you flip Cline's master switch:**
+> Settings → **"Enable lifecycle and tool hooks during task execution"** (defaults to off).
+> Until then nothing runs and nothing is logged — the install is silently inert.
+>
+> **Discovery is by filename, per platform.** Cline on **Windows** looks for `<Event>.ps1`
+> in `.clinerules/hooks/` (anything else — extensionless, `.cmd` — is invisible), so the
+> `nodejs/` and `bash/` cells are **macOS/Linux only**. On **Windows**, per-hook toggles are
+> not implemented in Cline yet (its UI says so) — enablement is simply *file present + master
+> switch on*. On macOS/Linux, each discovered hook also has its own per-hook toggle in the UI.
 
 **2 · Set your Prisma AIRS credentials**
 ```bash

--- a/Hooks/Cline/powershell/.clinerules/hooks/PostToolUse.cmd
+++ b/Hooks/Cline/powershell/.clinerules/hooks/PostToolUse.cmd
@@ -1,2 +1,0 @@
-@echo off
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0airs-hooks.ps1" -Vendor cline -EventName PostToolUse %*

--- a/Hooks/Cline/powershell/.clinerules/hooks/PostToolUse.ps1
+++ b/Hooks/Cline/powershell/.clinerules/hooks/PostToolUse.ps1
@@ -1,0 +1,6 @@
+# Cline hook shim — Prisma AIRS.
+# Cline on Windows discovers <Event>.ps1 in .clinerules/hooks/ (extensionless and
+# .cmd shims are BOTH invisible to its win32 discovery — the hook is silently
+# inert). Keep this file next to airs-hooks.ps1.
+& "$PSScriptRoot\airs-hooks.ps1" -Vendor cline -EventName PostToolUse
+exit $LASTEXITCODE

--- a/Hooks/Cline/powershell/.clinerules/hooks/PreToolUse.cmd
+++ b/Hooks/Cline/powershell/.clinerules/hooks/PreToolUse.cmd
@@ -1,2 +1,0 @@
-@echo off
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0airs-hooks.ps1" -Vendor cline -EventName PreToolUse %*

--- a/Hooks/Cline/powershell/.clinerules/hooks/PreToolUse.ps1
+++ b/Hooks/Cline/powershell/.clinerules/hooks/PreToolUse.ps1
@@ -1,0 +1,6 @@
+# Cline hook shim — Prisma AIRS.
+# Cline on Windows discovers <Event>.ps1 in .clinerules/hooks/ (extensionless and
+# .cmd shims are BOTH invisible to its win32 discovery — the hook is silently
+# inert). Keep this file next to airs-hooks.ps1.
+& "$PSScriptRoot\airs-hooks.ps1" -Vendor cline -EventName PreToolUse
+exit $LASTEXITCODE

--- a/Hooks/Cline/powershell/.clinerules/hooks/TaskComplete.cmd
+++ b/Hooks/Cline/powershell/.clinerules/hooks/TaskComplete.cmd
@@ -1,2 +1,0 @@
-@echo off
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0airs-hooks.ps1" -Vendor cline -EventName TaskComplete %*

--- a/Hooks/Cline/powershell/.clinerules/hooks/TaskComplete.ps1
+++ b/Hooks/Cline/powershell/.clinerules/hooks/TaskComplete.ps1
@@ -1,0 +1,6 @@
+# Cline hook shim — Prisma AIRS.
+# Cline on Windows discovers <Event>.ps1 in .clinerules/hooks/ (extensionless and
+# .cmd shims are BOTH invisible to its win32 discovery — the hook is silently
+# inert). Keep this file next to airs-hooks.ps1.
+& "$PSScriptRoot\airs-hooks.ps1" -Vendor cline -EventName TaskComplete
+exit $LASTEXITCODE

--- a/Hooks/Cline/powershell/.clinerules/hooks/UserPromptSubmit.cmd
+++ b/Hooks/Cline/powershell/.clinerules/hooks/UserPromptSubmit.cmd
@@ -1,2 +1,0 @@
-@echo off
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0airs-hooks.ps1" -Vendor cline -EventName UserPromptSubmit %*

--- a/Hooks/Cline/powershell/.clinerules/hooks/UserPromptSubmit.ps1
+++ b/Hooks/Cline/powershell/.clinerules/hooks/UserPromptSubmit.ps1
@@ -1,0 +1,6 @@
+# Cline hook shim — Prisma AIRS.
+# Cline on Windows discovers <Event>.ps1 in .clinerules/hooks/ (extensionless and
+# .cmd shims are BOTH invisible to its win32 discovery — the hook is silently
+# inert). Keep this file next to airs-hooks.ps1.
+& "$PSScriptRoot\airs-hooks.ps1" -Vendor cline -EventName UserPromptSubmit
+exit $LASTEXITCODE

--- a/Hooks/Cline/powershell/README.md
+++ b/Hooks/Cline/powershell/README.md
@@ -32,4 +32,12 @@ Pipe a malicious payload straight into the hook. **With a valid key it blocks**;
 
 With a valid key, a malicious input exits non-zero or prints a block decision and a benign input is silent. Unconfigured, every call warns on stderr (add `AIRS_REQUIRE_CONFIG=1` to block instead).
 
+> [!NOTE]
+> The command above pipes **straight into the engine** and proves detection — it does **not**
+> exercise Cline's hook *discovery*. Discovery is filename-based: on Windows, Cline runs the
+> `<Event>.ps1` shims in `.clinerules/hooks/` (which forward to `airs-hooks.ps1`). If the
+> engine passes this check but hooks never fire in Cline, verify the `.ps1` shims are present
+> and the master switch ("Enable lifecycle and tool hooks during task execution") is on —
+> a mis-named shim fails silently: no error, no log line.
+
 <div align="center"><sub>MIT © 2026 Palo Alto Networks &nbsp;·&nbsp; <a href="../README.md">Cline</a> &nbsp;·&nbsp; <a href="../../README.md">all agents</a></sub></div>

--- a/Hooks/Cline/tests/run-tests.sh
+++ b/Hooks/Cline/tests/run-tests.sh
@@ -51,6 +51,25 @@ assert_all() { # label fixture event want(ALLOW|NOT_ALLOW|BLOCK|ADVISE) [vendorO
   if [ "$ok" = 1 ]; then printf '  ok   %s ->%s\n' "$label" "$seen"; else printf '  FAIL %s: want %s, got%s\n' "$label" "$want" "$seen"; FAILED=1; fi
 }
 
+# ----------------------------------------------------------------------------
+# Shim-naming gate — Cline DISCOVERS hooks by filename, per host platform:
+# win32 wants <Event>.ps1, everything else wants an extensionless executable.
+# The engine tests below pipe straight into the engines and CANNOT catch a
+# mis-named shim (the exact failure that shipped: .cmd shims = silently inert
+# on Windows). This gate asserts the shipped filenames before anything runs.
+# ----------------------------------------------------------------------------
+SHIM_EVENTS=(UserPromptSubmit PreToolUse PostToolUse TaskComplete)
+for ev in "${SHIM_EVENTS[@]}"; do
+  [ -f "$HERE/../powershell/$CFG/hooks/$ev.ps1" ] || { echo "  FAIL shim naming: powershell cell must ship $ev.ps1 (win32 discovery)"; FAILED=1; }
+  for cell in nodejs bash; do
+    [ -f "$HERE/../$cell/$CFG/hooks/$ev" ] || { echo "  FAIL shim naming: $cell cell must ship extensionless $ev (unix discovery)"; FAILED=1; }
+    [ -x "$HERE/../$cell/$CFG/hooks/$ev" ] || { echo "  FAIL shim naming: $cell/$ev must be executable (0755)"; FAILED=1; }
+  done
+done
+stray="$(find "$HERE/../powershell/$CFG/hooks" -name '*.cmd' 2>/dev/null)"
+[ -n "$stray" ] && { echo "  FAIL shim naming: stray .cmd shim(s) — invisible to Cline on every platform: $stray"; FAILED=1; }
+[ "$FAILED" = 0 ] && echo "  ok   shim naming: powershell=<Event>.ps1, nodejs/bash=extensionless+exec"
+
 echo "== Cline [$MODE] runtimes: ${RUNTIMES[*]:-none} =="
 if [ ${#MISSING[@]} -gt 0 ]; then
   echo "   MISSING RUNTIME(S): ${MISSING[*]}"


### PR DESCRIPTION
## Summary

The `Hooks/Cline/powershell` cell could not fire on Windows as shipped. It installed its event shims as `<Event>.cmd`, but Cline's win32 discovery looks for `<Event>.ps1` (non-win32 wants extensionless `0755`). `.cmd` matches neither convention, so the cell was **silently inert**: no error, no log line, prompts flowed to the model unscanned — while the coverage table claimed Prompt/Pre-tool/Post-tool ✅. The engine itself (`airs-hooks.ps1`) was correct and blocks properly when invoked directly; only discovery was broken.

Measured on **Cline 4.1.16** (VS Code extension, Windows PowerShell 5.1): with the shipped `.cmd` shims, a DLP test prompt was answered and `prisma-airs.log` never appeared. Adding sibling `.ps1` forwarders — changing nothing else — made the very next prompt show `Hook: UserPromptSubmit → Aborted` with the AIRS block verdict logged.

## Changes

- `Cline/powershell/.clinerules/hooks/`: the four `.cmd` shims replaced with the validated `.ps1` forwarders (`& "$PSScriptRoot\airs-hooks.ps1" -Vendor cline -EventName <Event>; exit $LASTEXITCODE`).
- `Cline/tests/run-tests.sh`: a **shim-naming gate** — the powershell cell must ship `<Event>.ps1`, nodejs/bash must ship extensionless executables, and any stray `.cmd` fails the suite. The existing fixtures pipe straight into the engines and can never catch a mis-named shim, which is exactly how this shipped.
- READMEs: the enablement model is now documented — Cline's master switch (**"Enable lifecycle and tool hooks during task execution"**) defaults to OFF, so copying the folder alone is silently inert; `nodejs/` and `bash/` cells are macOS/Linux-only on discovery grounds; on Windows per-hook toggles are not implemented (Cline's UI says so) — file present + master switch is the whole model; and the engine-pipe verify command is flagged as bypassing discovery.

## Note on confidence

The `.ps1` naming rule is inferred from Cline's own hook scaffold generator (`process.platform === "win32" ? [{fileName:"TaskStart.ps1"}, …] : [{fileName:"TaskStart", mode:493}, …]`, identical in both bundles the extension ships) plus the empirical before/after above — not from reading the discovery filter directly.
